### PR TITLE
Run shutdown logic in separate thread and initialize network in parallel to disk reading

### DIFF
--- a/source/di.h
+++ b/source/di.h
@@ -17,10 +17,10 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <gctypes.h>
-
 #ifndef RRC_DI_H
 #define RRC_DI_H
+
+#include <gctypes.h>
 
 #define RRC_DI_PART_TYPE_DATA 0
 

--- a/source/di.h
+++ b/source/di.h
@@ -20,6 +20,7 @@
 #include <gctypes.h>
 
 #ifndef RRC_DI_H
+#define RRC_DI_H
 
 #define RRC_DI_PART_TYPE_DATA 0
 

--- a/source/main.c
+++ b/source/main.c
@@ -49,13 +49,6 @@ static GXRModeObj *rmode = NULL;
 
 int main(int argc, char **argv)
 {
-#define CHECK_EXIT()                                       \
-    if (rrc_shutting_down)                                 \
-    {                                                      \
-        rrc_dbg_printf("Home button pressed, exiting..."); \
-        return 0;                                          \
-    }
-
     s64 systime_start = gettime();
 
     // response codes for various library functions

--- a/source/main.c
+++ b/source/main.c
@@ -29,6 +29,7 @@
 #include "util.h"
 #include "shutdown.h"
 #include "di.h"
+#include "time.h"
 
 /* 100ms */
 #define DISKCHECK_DELAY 100000
@@ -54,6 +55,8 @@ int main(int argc, char **argv)
         rrc_dbg_printf("Home button pressed, exiting..."); \
         return 0;                                          \
     }
+
+    s64 systime_start = gettime();
 
     // response codes for various library functions
     int res;
@@ -210,6 +213,9 @@ check_cover_register:
     res = LWP_JoinThread(wiisocket_thread, NULL);
     RRC_ASSERTEQ(res, RRC_LWP_OK, "LWP_JoinThread wiisocket init");
     RRC_ASSERTEQ(wiisocket_res, 0, "wiisocket_init");
+
+    s64 systime_end = gettime();
+    rrc_dbg_printf("Time taken: %.3f seconds\n", ((f64)diff_msec(systime_start, systime_end)) / 1000.0);
 
     rrc_shutdown_join(shutdown_thread);
 

--- a/source/shutdown.c
+++ b/source/shutdown.c
@@ -22,7 +22,6 @@
 #include "shutdown.h"
 
 bool rrc_shutting_down = false;
-lwp_t rrc_shutdown_thread;
 
 #define SHUTDOWN_LOOP_DELAY 10000 /* 10ms */
 
@@ -46,13 +45,15 @@ static void *rrc_shutdown_handler(void *)
     return NULL;
 }
 
-void rrc_shutdown_spawn()
+lwp_t rrc_shutdown_spawn()
 {
-    RRC_ASSERT(
-        LWP_CreateThread(&rrc_shutdown_thread, rrc_shutdown_handler, NULL, NULL, 0, 0), "LWP_CreateThread for shutdown handler");
+    lwp_t thread;
+    RRC_ASSERTEQ(
+        LWP_CreateThread(&thread, rrc_shutdown_handler, NULL, NULL, 0, RRC_LWP_PRIO_IDLE), RRC_LWP_OK, "LWP_CreateThread for shutdown handler");
+    return thread;
 }
 
-void rrc_shutdown_join()
+void rrc_shutdown_join(lwp_t thread)
 {
-    RRC_ASSERT(LWP_JoinThread(rrc_shutdown_thread, NULL), "LWP_JoinThread for shutdown handler");
+    RRC_ASSERTEQ(LWP_JoinThread(thread, NULL), 0, "LWP_JoinThread for shutdown handler");
 }

--- a/source/shutdown.c
+++ b/source/shutdown.c
@@ -1,0 +1,58 @@
+/*
+    Copyright (C) 2025  Retro Rewind Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <ogc/lwp.h>
+#include <ogc/video.h>
+#include <wiiuse/wpad.h>
+#include "util.h"
+#include "shutdown.h"
+
+bool rrc_shutting_down = false;
+lwp_t rrc_shutdown_thread;
+
+#define SHUTDOWN_LOOP_DELAY 10000 /* 10ms */
+
+static void *rrc_shutdown_handler(void *)
+{
+    while (1)
+    {
+        WPAD_ScanPads();
+
+        if (WPAD_ButtonsDown(0) & WPAD_BUTTON_HOME)
+        {
+            rrc_shutting_down = true;
+            break;
+        }
+
+        usleep(SHUTDOWN_LOOP_DELAY);
+        VIDEO_WaitVSync();
+    }
+
+    rrc_dbg_printf("end of shutdown handler");
+    return NULL;
+}
+
+void rrc_shutdown_spawn()
+{
+    RRC_ASSERT(
+        LWP_CreateThread(&rrc_shutdown_thread, rrc_shutdown_handler, NULL, NULL, 0, 0), "LWP_CreateThread for shutdown handler");
+}
+
+void rrc_shutdown_join()
+{
+    RRC_ASSERT(LWP_JoinThread(rrc_shutdown_thread, NULL), "LWP_JoinThread for shutdown handler");
+}

--- a/source/shutdown.c
+++ b/source/shutdown.c
@@ -1,4 +1,7 @@
 /*
+    shutdown.h - Interface for the shutdown background thread, waits for Home
+    wpad presses and notifies other threads that periodically call `CHECK_EXIT()`.
+
     Copyright (C) 2025  Retro Rewind Team
 
     This program is free software: you can redistribute it and/or modify

--- a/source/shutdown.c
+++ b/source/shutdown.c
@@ -31,7 +31,8 @@ static void *rrc_shutdown_handler(void *)
     {
         WPAD_ScanPads();
 
-        if (WPAD_ButtonsDown(0) & WPAD_BUTTON_HOME)
+        int pressed = WPAD_ButtonsDown(0);
+        if (pressed & (WPAD_BUTTON_HOME | WPAD_CLASSIC_BUTTON_HOME))
         {
             rrc_shutting_down = true;
             break;

--- a/source/shutdown.h
+++ b/source/shutdown.h
@@ -1,0 +1,34 @@
+/*
+    Copyright (C) 2025  Retro Rewind Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef RRC_SHUTDOWN_H
+#define RRC_SHUTDOWN_H
+
+extern bool rrc_shutting_down;
+extern lwp_t rrc_shutdown_thread;
+
+/**
+ * Spawns the background thread for listening to Home menu button presses.
+ */
+void rrc_shutdown_spawn();
+
+/**
+ * Waits until the home button is pressed and the background thread exits.
+ */
+void rrc_shutdown_join();
+
+#endif

--- a/source/shutdown.h
+++ b/source/shutdown.h
@@ -19,16 +19,15 @@
 #define RRC_SHUTDOWN_H
 
 extern bool rrc_shutting_down;
-extern lwp_t rrc_shutdown_thread;
 
 /**
  * Spawns the background thread for listening to Home menu button presses.
  */
-void rrc_shutdown_spawn();
+lwp_t rrc_shutdown_spawn();
 
 /**
  * Waits until the home button is pressed and the background thread exits.
  */
-void rrc_shutdown_join();
+void rrc_shutdown_join(lwp_t);
 
 #endif

--- a/source/shutdown.h
+++ b/source/shutdown.h
@@ -1,4 +1,7 @@
 /*
+    shutdown.h - Interface for the shutdown background thread, waits for Home
+    wpad presses and notifies other threads that periodically call `CHECK_EXIT()`.
+
     Copyright (C) 2025  Retro Rewind Team
 
     This program is free software: you can redistribute it and/or modify

--- a/source/shutdown.h
+++ b/source/shutdown.h
@@ -18,6 +18,18 @@
 #ifndef RRC_SHUTDOWN_H
 #define RRC_SHUTDOWN_H
 
+/**
+ * Status for a shutdown interrupt
+ */
+#define RRC_SHUTDOWN_INTERRUPT (3000)
+
+#define CHECK_EXIT()                                       \
+    if (rrc_shutting_down)                                 \
+    {                                                      \
+        rrc_dbg_printf("Home button pressed, exiting..."); \
+        return RRC_SHUTDOWN_INTERRUPT;                     \
+    }
+
 extern bool rrc_shutting_down;
 
 /**

--- a/source/time.h
+++ b/source/time.h
@@ -1,0 +1,27 @@
+/*
+    time.h - Time-related functions.
+    Copyright (C) 2025  Retro Rewind Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef RRC_TIME_H
+#define RRC_TIME_H
+
+#include <gctypes.h>
+
+u32 diff_msec(u64 start, u64 end);
+s64 gettime();
+
+#endif

--- a/source/time.h
+++ b/source/time.h
@@ -21,7 +21,17 @@
 
 #include <gctypes.h>
 
-u32 diff_msec(u64 start, u64 end);
-s64 gettime();
+typedef s64 rrc_time_tick;
+
+/**
+ * Returns the difference of two ticks in milliseconds.
+ */
+u32 diff_msec(rrc_time_tick start, rrc_time_tick end);
+
+/**
+ * Gets the time in ticks.
+ * The return value is usually only meaningful when comparing it to another tick, e.g. using one of the `diff_*` functions.
+ */
+rrc_time_tick gettime();
 
 #endif

--- a/source/util.h
+++ b/source/util.h
@@ -36,10 +36,13 @@
 #define RRC_EXIT_DELAY 1000000
 #endif
 
-#define RRC_FATAL(...)      \
-    printf(__VA_ARGS__);    \
-    usleep(RRC_EXIT_DELAY); \
-    exit(1);
+#define RRC_FATAL(...)          \
+    do                          \
+    {                           \
+        printf(__VA_ARGS__);    \
+        usleep(RRC_EXIT_DELAY); \
+        exit(1);                \
+    } while (0);
 
 #define RRC_ASSERT(condition, what)                                        \
     do                                                                     \

--- a/source/util.h
+++ b/source/util.h
@@ -36,6 +36,9 @@
 #define RRC_EXIT_DELAY 1000000
 #endif
 
+#define RRC_LWP_PRIO_IDLE 0
+#define RRC_LWP_OK 0
+
 #define RRC_FATAL(...)          \
     do                          \
     {                           \


### PR DESCRIPTION
Commit 1: moves the `while(1)` loop that reads wpad input and exits into a separate thread. The thread sets a boolean that we periodically check in specific (arbitrarily chosen) spots in the main thread.

Commit 2: The `wiisocket_init()` call takes fairly long compared to the rest and we don't really need it immediately, so also do that in parallel.