### PR TITLE
Reorganise loader code

### DIFF
--- a/source/dol.h
+++ b/source/dol.h
@@ -1,0 +1,25 @@
+/*
+    dol.h - definition of DOL (static executable) structure
+
+    Copyright (C) 2025  Retro Rewind Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* See: https://wiki.tockdom.com/wiki/DOL_(File_Format) */
+
+#ifndef RRC_DOL_H
+#define RRC_DOL_H
+
+#endif

--- a/source/loader.c
+++ b/source/loader.c
@@ -1,0 +1,128 @@
+/*
+    loader.h - main app loader and patcher
+
+    Copyright (C) 2025  Retro Rewind Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <gccore.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "util.h"
+#include "di.h"
+#include "loader.h"
+#include "shutdown.h"
+#include "res.h"
+
+int rrc_loader_locate_data_part(u32 *data_part_offset)
+{
+    int res;
+    struct rrc_di_part_group part_groups[4] __attribute__((aligned(32)));
+    res = rrc_di_unencrypted_read(&part_groups, sizeof(part_groups), RRC_DI_PART_GROUPS_OFFSET >> 2);
+    RRC_ASSERTEQ(res, RRC_DI_LIBDI_OK, "rrc_di_unencrypted_read for partition group");
+
+    struct rrc_di_part_info partitions[4] __attribute__((aligned(32)));
+
+    for (u32 i = 0; i < 4 && *data_part_offset == UINT32_MAX; i++)
+    {
+        if (part_groups[i].count == 0 && part_groups[i].offset == 0)
+        {
+            // No partitions in this group.
+            continue;
+        }
+
+        if (part_groups[i].count > 4)
+        {
+            RRC_FATAL("too many partitions in group %d (max: 4, got: %d)", i, part_groups[i].count);
+        }
+
+        res = rrc_di_unencrypted_read(&partitions, sizeof(partitions), part_groups[i].offset);
+        RRC_ASSERTEQ(res, RRC_DI_LIBDI_OK, "rrc_di_unencrypted_read for partition");
+        for (u32 j = 0; j < part_groups[i].count; j++)
+        {
+            if (partitions[j].type == RRC_DI_PART_TYPE_DATA)
+            {
+                *data_part_offset = partitions[j].offset;
+                break;
+            }
+        }
+    }
+
+    return 0;
+}
+
+/* 100ms */
+int rrc_loader_await_mkw()
+{
+#define DISKCHECK_DELAY 100000
+    int res;
+    unsigned int status;
+    bool disc_printed = false;
+
+check_cover_register:
+    CHECK_EXIT();
+
+    res = rrc_di_get_low_cover_register(&status);
+    RRC_ASSERTEQ(res, RRC_DI_RET_OK, "rrc_di_getlowcoverregister");
+
+    // if status = 0 that means that a disk is inserted
+    if ((status & RRC_DI_DICVR_CVR) != 0)
+    {
+    missing_mkwii_alert:
+        if (!disc_printed)
+        {
+            printf("Please insert Mario Kart Wii into the console.\n");
+            disc_printed = true;
+        }
+        CHECK_EXIT();
+        usleep(DISKCHECK_DELAY);
+        goto check_cover_register;
+    }
+
+    /* we need to check we actually inserted mario kart wii */
+    struct rrc_di_disk_id did;
+    res = rrc_di_get_disk_id(&did);
+    /* likely drive wasnt spun up */
+    if (res != RRC_DI_LIBDI_EIO)
+    {
+        /* spin up the drive */
+        rrc_dbg_printf("failed to read disk_id: attempting drive reset\n");
+        RRC_ASSERTEQ(rrc_di_reset(), RRC_DI_LIBDI_OK, "rrc_di_reset");
+        res = rrc_di_get_disk_id(&did);
+        RRC_ASSERTEQ(res, RRC_DI_LIBDI_OK, "rrc_di_get_disk_id (could not initialise drive)");
+    }
+
+    /* this excludes region identifier */
+#define DISKID_MKW_ID "RMC"
+    if (memcmp(did.game_id, DISKID_MKW_ID, strlen(DISKID_MKW_ID)))
+        goto missing_mkwii_alert;
+
+    char gameId[16];
+    snprintf(
+        gameId, sizeof(gameId), "%c%c%c%cD%02x", did.game_id[0],
+        did.game_id[1], did.game_id[2], did.game_id[3], did.disc_ver);
+
+    printf("Game ID/Rev: %s\n", gameId);
+    CHECK_EXIT();
+
+    return RRC_RES_OK;
+#undef DISKCHECK_DELAY
+}
+
+int rrc_loader_load()
+{
+    return 0;
+}

--- a/source/loader.h
+++ b/source/loader.h
@@ -1,0 +1,45 @@
+/*
+    loader.h - main app loader implementation header
+
+    Copyright (C) 2025  Retro Rewind Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef RRC_LOADER_H
+#define RRC_LOADER_H
+
+/*
+ * Spins until Mario Kart Wii is inserted into the disc drive.
+ *
+ * Returns normal RRC exit codes.
+ */
+int rrc_loader_await_mkw();
+
+/*
+ * Locate the data partition and return it. On failure, `part' is set to NULL.
+ */
+int rrc_loader_locate_data_part(u32 *part);
+
+/*
+ * This routine applies all patches from code.pul as well as setting key memory addresses
+ * appropriately before fully loading the DOL and launching Mario Kart Wii.
+ *
+ * TODO: For now, this does not apply patches, but we'll want to do that.
+ * TODO: This routine should be resilient against things such as the SD card or disc being ejected.
+ * This function should always return a status code on failure and NEVER CRASH. On success, it never returns.
+ */
+int rrc_loader_load();
+
+#endif

--- a/source/res.h
+++ b/source/res.h
@@ -1,0 +1,35 @@
+/*
+    res.h - return codes from rrc routines
+
+    Copyright (C) 2025  Retro Rewind Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef RRC_RES_H
+#define RRC_RES_H
+
+enum rrc_res
+{
+    /*
+     * Success status
+     */
+    RRC_RES_OK = 0,
+    /*
+     * Status for a shutdown interrupt
+     */
+    RRC_RES_SHUTDOWN_INTERRUPT = 3000
+};
+
+#endif

--- a/source/shutdown.h
+++ b/source/shutdown.h
@@ -21,16 +21,13 @@
 #ifndef RRC_SHUTDOWN_H
 #define RRC_SHUTDOWN_H
 
-/**
- * Status for a shutdown interrupt
- */
-#define RRC_SHUTDOWN_INTERRUPT (3000)
+#include "res.h"
 
 #define CHECK_EXIT()                                       \
     if (rrc_shutting_down)                                 \
     {                                                      \
         rrc_dbg_printf("Home button pressed, exiting..."); \
-        return RRC_SHUTDOWN_INTERRUPT;                     \
+        return RRC_RES_SHUTDOWN_INTERRUPT;                 \
     }
 
 extern bool rrc_shutting_down;


### PR DESCRIPTION
Moves loader code to its own files `loader.{h,c}`. Adds some comments with TODOs as well and makes an empty dol.h.