### PR TITLE
Option saving/loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ LDFLAGS	=	-g $(MACHDEP) -Wl,-Map,$(notdir $@).map
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:=	-lcurl -lfat -lzip -lbz2 -ldi -lz -lwiisocket -lmbedtls -lmbedcrypto -lmbedx509 -lwiiuse -lbte -logc -lm
+LIBS	:=	-lcurl -lfat -lzip -lbz2 -ldi -lmxml -lz -lwiisocket -lmbedtls -lmbedcrypto -lmbedx509 -lwiiuse -lbte -logc -lm
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/source/main.c
+++ b/source/main.c
@@ -104,43 +104,6 @@ int main(int argc, char **argv)
     rrc_con_update("Initialise SD card", 2);
     RRC_ASSERTEQ(fatInitDefault(), true, "fatInitDefault()");
 
-#define INTERRUPT_TIME 3000000 /* 3 seconds */
-    rrc_con_clear(true);
-    rrc_con_print_text_centered(_RRC_PRINTF_ROW, "Press A to launch, or press + to load settings.");
-    rrc_con_print_text_centered(_RRC_PRINTF_ROW + 1, "Auto-launching in 3 seconds...");
-
-    for (int i = 0; i < INTERRUPT_TIME / RRC_WPAD_LOOP_TIMEOUT; i++)
-    {
-        WPAD_ScanPads();
-
-        int pressed = WPAD_ButtonsDown(0);
-        if (pressed & RRC_WPAD_HOME_MASK)
-        {
-            return 0;
-        }
-
-        if (pressed & RRC_WPAD_A_MASK)
-        {
-            break;
-        }
-
-        if (pressed & RRC_WPAD_PLUS_MASK)
-        {
-            switch (rrc_settings_display())
-            {
-            case RRC_SETTINGS_LAUNCH:
-                goto interrupt_loop_end;
-            case RRC_SETTINGS_EXIT:
-                return 0;
-            }
-        }
-
-        usleep(RRC_WPAD_LOOP_TIMEOUT);
-    }
-interrupt_loop_end:
-
-    rrc_con_clear(true);
-
     rrc_con_update("Spawn background threads", 5);
 
     // Initializing the network can take fairly long (seconds).
@@ -216,58 +179,42 @@ interrupt_loop_end:
     RRC_ASSERTEQ(res, RRC_LWP_OK, "LWP_JoinThread wiisocket init");
     RRC_ASSERTEQ(wiisocket_res, 0, "wiisocket_init");
 
-    char *versionsfile = NULL;
-    char *deleted_versionsfile = NULL;
-    int num_deleted_files = 0;
-    struct rrc_versionsfile_deleted_file *deleted_files = NULL;
-    char **zip_urls = NULL;
-    int *update_versions = NULL;
-    int count = 0;
-    res = rrc_versionsfile_get_versionsfile(&versionsfile);
-    rrc_con_update("Get Versions", 0);
-    if (res < 0)
-    {
-        RRC_FATAL("couldnt get version file! res: %i\n", res);
-    }
-    int current = rrc_update_get_current_version();
-    RRC_ASSERT(current >= 0, "failed to read current version file");
-    rrc_dbg_printf("Current version: %i\n", current);
+#define INTERRUPT_TIME 3000000 /* 3 seconds */
+    rrc_con_clear(true);
+    rrc_con_print_text_centered(_RRC_PRINTF_ROW, "Press A to launch, or press + to load settings.");
+    rrc_con_print_text_centered(_RRC_PRINTF_ROW + 1, "Auto-launching in 3 seconds...");
 
-    res = rrc_versionsfile_get_necessary_urls_and_versions(versionsfile, current, &count, &zip_urls, &update_versions);
-    if (res < 0)
+    for (int i = 0; i < INTERRUPT_TIME / RRC_WPAD_LOOP_TIMEOUT; i++)
     {
-        RRC_FATAL("couldnt get necessary download urls! res: %i\n", res);
-    }
+        WPAD_ScanPads();
 
-    res = rrc_versionsfile_get_removed_files(&deleted_versionsfile);
-    if (res < 0)
-    {
-        RRC_FATAL("couldnt get files to remove! res: %i\n", res);
-    }
-
-    res = rrc_versionsfile_parse_deleted_files(deleted_versionsfile, current, &deleted_files, &num_deleted_files);
-    if (res < 0)
-    {
-        RRC_FATAL("couldnt parse deleted files! res: %i\n", res);
-    }
-    rrc_dbg_printf("%i updates\n", count);
-    struct rrc_update_state state =
+        int pressed = WPAD_ButtonsDown(0);
+        if (pressed & RRC_WPAD_HOME_MASK)
         {
-            .current_update_num = 0,
-            .d_ptr = NULL,
-            .num_updates = count,
-            .update_urls = zip_urls,
-            .update_versions = update_versions,
-            .current_version = current,
-            .num_deleted_files = num_deleted_files,
-            .deleted_files = deleted_files};
+            return 0;
+        }
 
-    struct rrc_update_result upres;
-    rrc_update_do_updates(&state, &upres);
-    if (upres.ecode != RRC_UPDATE_EOK)
-    {
-        RRC_FATAL("Update failed: %d (%d)\n", upres.ecode, upres.inner.errnocode);
+        if (pressed & RRC_WPAD_A_MASK)
+        {
+            break;
+        }
+
+        if (pressed & RRC_WPAD_PLUS_MASK)
+        {
+            switch (rrc_settings_display())
+            {
+            case RRC_SETTINGS_LAUNCH:
+                goto interrupt_loop_end;
+            case RRC_SETTINGS_EXIT:
+                return 0;
+            }
+        }
+
+        usleep(RRC_WPAD_LOOP_TIMEOUT);
     }
+interrupt_loop_end:
+
+    rrc_con_clear(true);
 
     rrc_con_update("Initialise DVD: Read Game DOL", 25);
 

--- a/source/main.c
+++ b/source/main.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <fat.h>
 #include <curl/curl.h>
+#include <mxml.h>
 #include <sys/statvfs.h>
 #include <errno.h>
 
@@ -100,6 +101,9 @@ int main(int argc, char **argv)
     res = WPAD_Init();
     RRC_ASSERTEQ(res, WPAD_ERR_NONE, "WPAD_Init");
 
+    rrc_con_update("Initialise SD card", 2);
+    RRC_ASSERTEQ(fatInitDefault(), true, "fatInitDefault()");
+
 #define INTERRUPT_TIME 3000000 /* 3 seconds */
     rrc_con_clear(true);
     rrc_con_print_text_centered(_RRC_PRINTF_ROW, "Press A to launch, or press + to load settings.");
@@ -147,9 +151,6 @@ interrupt_loop_end:
     lwp_t wiisocket_thread;
     res = LWP_CreateThread(&wiisocket_thread, wiisocket_init_thread_callback, &wiisocket_res, NULL, 0, RRC_LWP_PRIO_IDLE);
     RRC_ASSERTEQ(res, RRC_LWP_OK, "LWP_CreateThread for wiisocket init");
-
-    rrc_con_update("Initialise SD card", 6);
-    RRC_ASSERTEQ(fatInitDefault(), true, "fatInitDefault()");
 
     rrc_con_update("Initialise DVD", 10);
 

--- a/source/settingsfile.c
+++ b/source/settingsfile.c
@@ -1,0 +1,140 @@
+#include <stdio.h>
+#include <gctypes.h>
+#include <string.h>
+#include <errno.h>
+#include "settingsfile.h"
+#include "util.h"
+
+#define RRC_SETTINGSFILE_PATH "RetroRewind6/.settings"
+#define RRC_SETTINGSFILE_MY_STUFF_KEY "My Stuff"
+#define RRC_SETTINGSFILE_LANGUAGE_KEY "Language"
+#define RRC_SETTINGSFILE_SAVEGAME_KEY "Separate savegame"
+#define RRC_SETTINGSFILE_MAGIC 1920234103
+#define RRC_SETTINGSFILE_VERSION 0
+
+static u32 expect_read_u32(FILE *file, const char *what)
+{
+    u32 val;
+    RRC_ASSERTEQ(fread(&val, sizeof(u32), 1, file), 1, what);
+    return val;
+}
+
+static void rrc_settings_file_write_header(FILE *file, u32 entry_count)
+{
+    u32 magic = RRC_SETTINGSFILE_MAGIC;
+    RRC_ASSERTEQ(fwrite(&magic, sizeof(magic), 1, file), 1, "write magic");
+
+    u32 version = RRC_SETTINGSFILE_VERSION;
+    RRC_ASSERTEQ(fwrite(&version, sizeof(version), 1, file), 1, "write version");
+
+    RRC_ASSERTEQ(fwrite(&entry_count, sizeof(entry_count), 1, file), 1, "write entry count");
+}
+
+FILE *rrc_settingsfile_create()
+{
+    FILE *file = fopen(RRC_SETTINGSFILE_PATH, "w");
+    if (file)
+    {
+        rrc_settings_file_write_header(file, 0);
+        fseek(file, 0, SEEK_SET);
+    }
+    return file;
+}
+
+enum rrc_settingsfile_status rrc_settingsfile_parse(struct rrc_settingsfile *settings)
+{
+    FILE *file = fopen(RRC_SETTINGSFILE_PATH, "r");
+    if (!file)
+    {
+        if (errno == ENOENT)
+        {
+            // File doesn't exist. Create it and initialize it with defaults.
+            file = rrc_settingsfile_create();
+            if (!file)
+            {
+                return RRC_SETTINGS_FILE_FOPEN;
+            }
+        }
+        else
+        {
+            return RRC_SETTINGS_FILE_FOPEN;
+        }
+    }
+
+    RRC_ASSERTEQ(expect_read_u32(file, "read file header"), RRC_SETTINGSFILE_MAGIC, "magic header mismatch");
+    expect_read_u32(file, "read file version"); // Version unused for now.
+
+    u32 entry_count = expect_read_u32(file, "read entry count");
+
+    settings->my_stuff = RRC_SETTINGSFILE_DEFAULT;
+    settings->language = RRC_SETTINGSFILE_DEFAULT;
+    settings->savegame = RRC_SETTINGSFILE_DEFAULT;
+
+    for (int i = 0; i < entry_count; i++)
+    {
+        // Read key length.
+        u32 key_length = expect_read_u32(file, "read key length");
+
+        RRC_ASSERT(key_length < 32, "setting keys should not be longer than 32 characters");
+
+        // Read the key.
+        char key[32];
+        int read = fread((void *)key, sizeof(char), key_length, file);
+        RRC_ASSERT(read == key_length, "failed to read key");
+        key[key_length] = 0;
+
+        // Read value length. For now we always have u32 values.
+        u32 value_length = expect_read_u32(file, "read value length");
+        RRC_ASSERTEQ(value_length, 4, "value should always be a u32");
+
+        // Read the value. Currently this is always a u32.
+        u32 value;
+        read = fread((void *)&value, sizeof(u32), 1, file);
+        RRC_ASSERT(read == 1, "failed to read a u32 value");
+
+        if (strcmp(key, "My Stuff") == 0)
+        {
+            settings->my_stuff = value;
+        }
+        else if (strcmp(key, "Language") == 0)
+        {
+            settings->language = value;
+        }
+        else if (strcmp(key, "Separate savegame") == 0)
+        {
+            settings->savegame = value;
+        }
+    }
+
+    fclose(file);
+    return RRC_SETTINGSFILE_OK;
+}
+
+static void rrc_settingsfile_set_option(FILE *file, const char *key, u32 value)
+{
+    u32 key_len = strlen(key);
+    RRC_ASSERTEQ(fwrite(&key_len, sizeof(key_len), 1, file), 1, "write len");
+    RRC_ASSERTEQ(fwrite(key, 1, key_len, file), key_len, "write key");
+
+    u32 val_len = 4; // always a u32
+    RRC_ASSERTEQ(fwrite(&val_len, sizeof(val_len), 1, file), 1, "write value length");
+    RRC_ASSERTEQ(fwrite(&value, sizeof(value), 1, file), 1, "write value");
+}
+
+/**
+ * Writes an `rrc_settingsfile` to the sd card.
+ */
+enum rrc_settingsfile_status rrc_settingsfile_store(struct rrc_settingsfile *settings)
+{
+    FILE *file = fopen(RRC_SETTINGSFILE_PATH, "w");
+    RRC_ASSERT(file != NULL, "failed to open file");
+
+    rrc_settings_file_write_header(file, 3);
+
+    rrc_settingsfile_set_option(file, RRC_SETTINGSFILE_MY_STUFF_KEY, settings->my_stuff);
+    rrc_settingsfile_set_option(file, RRC_SETTINGSFILE_LANGUAGE_KEY, settings->language);
+    rrc_settingsfile_set_option(file, RRC_SETTINGSFILE_SAVEGAME_KEY, settings->savegame);
+
+    fclose(file);
+    return RRC_SETTINGSFILE_OK;
+}

--- a/source/settingsfile.c
+++ b/source/settingsfile.c
@@ -1,3 +1,41 @@
+/*
+    settingsfile.c - implementation of the settings file
+    Copyright (C) 2025  Retro Rewind Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+    Currently the file format is defined as follows:
+
+    | Name              | Size in bytes      |
+    |-------------------|--------------------|
+    | Format Magic      | 4                  | (always the value of `RRC_SETTINGSFILE_MAGIC`)
+    | Format Version    | 4                  |
+    | Number of Entries | 4                  |
+    | List of Entries   | Variable           |
+
+
+    Entry Format:
+    | Name            | Size in bytes (BE) |
+    |-----------------|--------------------|
+    | Key Name Length | 4                  |
+    | Key Name        | Variable           |
+    | Value Length    | 4                  |
+    | Value           | Variable           |
+*/
+
 #include <stdio.h>
 #include <gctypes.h>
 #include <string.h>

--- a/source/settingsfile.h
+++ b/source/settingsfile.h
@@ -1,0 +1,32 @@
+#ifndef RRC_SETTINGSFILE_H
+#define RRC_SETTINGSFILE_H
+
+#define RRC_SETTINGSFILE_DEFAULT 0 /* disabled */
+
+enum rrc_settingsfile_status
+{
+    /** Operation was sucessful */
+    RRC_SETTINGSFILE_OK,
+    /** Failed to open/create settings file */
+    RRC_SETTINGS_FILE_FOPEN
+};
+
+struct rrc_settingsfile
+{
+    int my_stuff;
+    int language;
+    int savegame;
+};
+
+/**
+ * Initializes an `rrc_settingsfile` by reading it from the sd card.
+ * If it does not already exist, this function will create it and initialize the file with default values.
+ */
+enum rrc_settingsfile_status rrc_settingsfile_parse(struct rrc_settingsfile *settings);
+
+/**
+ * Writes an `rrc_settingsfile` to the sd card.
+ */
+enum rrc_settingsfile_status rrc_settingsfile_store(struct rrc_settingsfile *settings);
+
+#endif

--- a/source/settingsfile.h
+++ b/source/settingsfile.h
@@ -1,3 +1,21 @@
+/*
+    settingsfile.h - API for interacting with the settings file that stores the selected settings
+    Copyright (C) 2025  Retro Rewind Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef RRC_SETTINGSFILE_H
 #define RRC_SETTINGSFILE_H
 

--- a/source/update/update.h
+++ b/source/update/update.h
@@ -138,6 +138,11 @@ int rrc_update_ecode_to_string(int code);
     Returns 0 on success and a negative code on fail.
     `res' is a pointer to a valid `struct rrc_update_result' on return.
 */
-void rrc_update_do_updates(struct rrc_update_state *state, struct rrc_update_result *res);
+void rrc_update_do_updates_with_state(struct rrc_update_state *state, struct rrc_update_result *res);
+
+/*
+    Checks if updates are needed and download them. See `rrc_update_do_updates_with_state` for more details
+*/
+void rrc_update_do_updates();
 
 #endif


### PR DESCRIPTION
- Move all the update logic out of main into its own `rrc_update_do_updates` function. This is so that we can call it when "Perform updates" is pressed in the settings.
- Implement `settingsfile.c` which can load a settings file on the sd card into memory and save it again.
- Parse possible choices in `RetroRewind6/xml/RetroRewind6.xml`
- Some small refactoring/simplification in the settings code (we now store an `options_count` in the struct and no longer have a `NULL` at the end of the arrays, so we can replace some loops to find the array length by reading that count field directly)