### PR TITLE
Add version info to splash

### DIFF
--- a/source/console.c
+++ b/source/console.c
@@ -21,7 +21,9 @@
 #include <string.h>
 #include <gctypes.h>
 
+#include "update/update.h"
 #include "console.h"
+#include "util.h"
 
 const int bg_colour_cycle_len = 12;
 const char *bg_colour_cycle[] =
@@ -52,6 +54,7 @@ int rrc_con_line_width_chars = 0;
 /* 100 = 100% */
 int rrc_con_progress_percent = 0;
 char *rrc_con_current_action;
+int cached_version = -1;
 
 void rrc_con_set_action(char *action)
 {
@@ -129,6 +132,18 @@ void rrc_con_display_splash()
     int middle_off = splash_len / 2;
     rrc_con_cursor_seek_to_row_centered(_RRC_SPLASH_ROW, middle_off);
     _rrc_con_print_splash();
+
+    if (cached_version == -1)
+    {
+        cached_version = rrc_update_get_current_version();
+        if (cached_version < 0)
+        {
+            RRC_FATAL("failed to get version: ret = %i", cached_version);
+        }
+    }
+    char vertext[32];
+    snprintf(vertext, 32, "Version: %i.%i.%i", cached_version / 100, (cached_version / 10) % 10, cached_version % 10);
+    rrc_con_print_text_centered(_RRC_SPLASH_ROW + 1, vertext);
 }
 
 void rrc_con_display_progress_bar()

--- a/source/main.c
+++ b/source/main.c
@@ -95,14 +95,14 @@ int main(int argc, char **argv)
     // init video, setup console framebuffer
     video_init();
 
+    rrc_dbg_printf("Initialising SD card");
+    RRC_ASSERTEQ(fatInitDefault(), true, "fatInitDefault()");
+
     rrc_con_update("Initialise controllers", 0);
 
     rrc_dbg_printf("init controllers\n");
     res = WPAD_Init();
     RRC_ASSERTEQ(res, WPAD_ERR_NONE, "WPAD_Init");
-
-    rrc_con_update("Initialise SD card", 2);
-    RRC_ASSERTEQ(fatInitDefault(), true, "fatInitDefault()");
 
     rrc_con_update("Spawn background threads", 5);
 

--- a/source/update/update.c
+++ b/source/update/update.c
@@ -32,18 +32,17 @@
 #include "../console.h"
 #include "../time.h"
 
-#define _RRC_VERSIONFILE "RetroRewind6/version.txt"
 #define _RRC_UPDATE_ZIP_NAME "update.zip"
 
 int rrc_update_get_current_version()
 {
-    FILE *file = fopen(_RRC_VERSIONFILE, "r");
+    FILE *file = fopen(RRC_VERSIONFILE, "r");
     if (file == NULL)
         return -5;
 
     int fd = fileno(file);
     struct stat statbuf;
-    int res = stat(_RRC_VERSIONFILE, &statbuf);
+    int res = stat(RRC_VERSIONFILE, &statbuf);
     if (res != 0)
         return -4;
 
@@ -71,7 +70,7 @@ int rrc_update_set_current_version(int version)
     char out[32];
     int written = snprintf(out, sizeof(out), "%d.%d.%d", p1, p2, version);
     RRC_ASSERT(written < sizeof(out), "version string too long");
-    FILE *file = fopen(_RRC_VERSIONFILE, "w");
+    FILE *file = fopen(RRC_VERSIONFILE, "w");
     if (file == NULL)
         return -5;
 

--- a/source/update/update.h
+++ b/source/update/update.h
@@ -21,6 +21,8 @@
 
 #include <curl/curl.h>
 
+#define RRC_VERSIONFILE "RetroRewind6/version.txt"
+
 /* Holds all info related to an update or sequence of updates */
 struct rrc_update_state
 {
@@ -41,6 +43,11 @@ struct rrc_update_state
     /* Files to delete. */
     struct rrc_versionsfile_deleted_file *deleted_files;
 };
+
+/*
+    Stores version string in `verstring'. `n' is the size of `verstring' to help catch buffer overruns.
+*/
+int rrc_update_get_current_version_str(char **verstring, int n);
 
 /*
     Returns an int specifying version information from version.txt.

--- a/source/update/update.h
+++ b/source/update/update.h
@@ -45,11 +45,6 @@ struct rrc_update_state
 };
 
 /*
-    Stores version string in `verstring'. `n' is the size of `verstring' to help catch buffer overruns.
-*/
-int rrc_update_get_current_version_str(char **verstring, int n);
-
-/*
     Returns an int specifying version information from version.txt.
     E.g., 4.2.0 = 420
     Returns negative status on failure.


### PR DESCRIPTION
Closes #9 

Display version on-screen. The version is cached on first call to displaying the splash.