### PR TITLE
Add prompt to insert disc

### DIFF
--- a/source/loader.c
+++ b/source/loader.c
@@ -82,10 +82,12 @@ check_cover_register:
     {
     missing_mkwii_alert:
         char *lines[] = {
+            "Mario Kart Wii is not inserted!",
+            ""
             "Please insert Mario Kart Wii into the console,",
             "and select OK when done."};
 
-        enum rrc_prompt_result pres = rrc_prompt_ok_cancel(xfb, lines, 2);
+        enum rrc_prompt_result pres = rrc_prompt_ok_cancel(xfb, lines, 4);
         RRC_ASSERT(pres != RRC_PROMPT_RESULT_ERROR, "failed to generate prompt");
 
         if (pres == RRC_PROMPT_RESULT_OK)

--- a/source/loader.c
+++ b/source/loader.c
@@ -71,7 +71,6 @@ int rrc_loader_await_mkw(void *xfb)
 {
     int res;
     unsigned int status;
-    bool disc_printed = false;
 
 check_cover_register:
     res = rrc_di_get_low_cover_register(&status);
@@ -83,7 +82,7 @@ check_cover_register:
     missing_mkwii_alert:
         char *lines[] = {
             "Mario Kart Wii is not inserted!",
-            ""
+            "",
             "Please insert Mario Kart Wii into the console,",
             "and select OK when done."};
 

--- a/source/loader.h
+++ b/source/loader.h
@@ -26,9 +26,9 @@
 /*
  * Spins until Mario Kart Wii is inserted into the disc drive.
  *
- * Returns normal RRC exit codes.
+ * Returns normal RRC status codes.
  */
-int rrc_loader_await_mkw();
+int rrc_loader_await_mkw(void *xfb);
 
 /*
  * Locate the data partition and return it. On failure, `part' is set to NULL.

--- a/source/main.c
+++ b/source/main.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
 
     rrc_con_update("Initialise DVD: Check for Mario Kart Wii", 12);
     /*  We should load Mario Kart Wii before doing anything else */
-    res = rrc_loader_await_mkw();
+    res = rrc_loader_await_mkw(xfb);
 
     /*  TODO: From this point in the full launcher we will set a timeout of, say, 2 seconds.
         If some button such as A is pressed in that window, initialise the full channel.

--- a/source/main.c
+++ b/source/main.c
@@ -42,6 +42,7 @@
 #include "update/update.h"
 #include "prompt.h"
 #include "gui.h"
+#include "res.h"
 
 /* 100ms */
 #define DISKCHECK_DELAY 100000
@@ -52,7 +53,6 @@ void *wiisocket_init_thread_callback(void *res)
     // because we want to assert everything from the main thread rather than asserting in here
     // so that we don't potentially exit(1) from another thread while the main thread is doing some important reading/patching.
     *(int *)res = wiisocket_init();
-    rrc_dbg_printf("network initialised with status %d\n", *(int *)res);
     return NULL;
 }
 
@@ -99,6 +99,10 @@ int main(int argc, char **argv)
     rrc_con_update("Initialise DVD: Check for Mario Kart Wii", 12);
     /*  We should load Mario Kart Wii before doing anything else */
     res = rrc_loader_await_mkw(xfb);
+    if (res == RRC_RES_SHUTDOWN_INTERRUPT)
+    {
+        exit(0);
+    }
 
     /*  TODO: From this point in the full launcher we will set a timeout of, say, 2 seconds.
         If some button such as A is pressed in that window, initialise the full channel.

--- a/source/prompt.h
+++ b/source/prompt.h
@@ -24,7 +24,9 @@ enum rrc_prompt_result
     /* Problem with input parameters, usually */
     RRC_PROMPT_RESULT_ERROR = -1,
     RRC_PROMPT_RESULT_YES = 0,
-    RRC_PROMPT_RESULT_NO = 1
+    RRC_PROMPT_RESULT_NO = 1,
+    RRC_PROMPT_RESULT_OK = 2,
+    RRC_PROMPT_RESULT_CANCEL = 3
 };
 
 /*
@@ -34,9 +36,17 @@ enum rrc_prompt_result
     `lines' is limited to 10 entries. Each line cannot exceed the console line width.
     `n' contains the amount of lines in `lines'.
 
-    This function returns RRC_PROMPT_RESULT_YES if `yes' is selected and RRC_PROMPT_RESULT_NO if `no' is selected.
+    This function returns RRC_PROMPT_RESULT_YES if `Yes' is selected and RRC_PROMPT_RESULT_NO if `No' is selected.
     On error, RRC_PROMPT_RESULT_ERROR is returned.
 */
 enum rrc_prompt_result rrc_prompt_yes_no(void *old_xfb, char **lines, int n);
+
+/*
+    See `rrc_prompt_yes_no' for a description of prompts.
+
+    This function returns RRC_PROMPT_RESULT_OK if `OK' is selected and RRC_PROMPT_RESULT_CANCEL if `Cancel' is selected.
+    On error, RRC_PROMPT_RESULT_ERROR is returned.
+*/
+enum rrc_prompt_result rrc_prompt_ok_cancel(void *old_xfb, char **lines, int n);
 
 #endif


### PR DESCRIPTION
Closes #26 

Improves the UX when Mario Kart Wii is not inserted by adding a dedicated prompt for it. Also allows the user to cancel and exit.