### PR TITLE
Add update size checking

### DIFF
--- a/source/settings.c
+++ b/source/settings.c
@@ -323,7 +323,7 @@ enum rrc_settings_result rrc_settings_display(void *xfb)
                     enum rrc_prompt_result result = rrc_prompt_yes_no(xfb, lines, 1);
                     if (result == RRC_PROMPT_RESULT_YES)
                     {
-                        rrc_update_do_updates();
+                        rrc_update_do_updates(xfb);
                     }
                 }
                 else if (option->label == exit_label)

--- a/source/settings.c
+++ b/source/settings.c
@@ -324,6 +324,8 @@ enum rrc_settings_result rrc_settings_display(void *xfb)
                     if (result == RRC_PROMPT_RESULT_YES)
                     {
                         rrc_update_do_updates(xfb);
+                        rrc_con_clear(true);
+                        break;
                     }
                 }
                 else if (option->label == exit_label)

--- a/source/update/update.c
+++ b/source/update/update.c
@@ -363,13 +363,13 @@ int rrc_update_get_total_update_size(struct rrc_update_state *state, curl_off_t 
 {
     *size = 0;
 
-    for(int i = 0; i < state->num_updates; i++)
+    for (int i = 0; i < state->num_updates; i++)
     {
         int ret;
         curl_off_t this_size;
 
         ret = _rrc_update_get_zip_size(state->update_urls[i], &this_size);
-        if(ret != 0)
+        if (ret != 0)
         {
             *size = 0;
             return -ret;
@@ -385,7 +385,7 @@ int rrc_update_is_large(struct rrc_update_state *state, curl_off_t *size)
 {
     int ret = rrc_update_get_total_update_size(state, size);
 
-    if(ret < 0)
+    if (ret < 0)
     {
         return ret;
     }
@@ -489,7 +489,7 @@ void rrc_update_do_updates_with_state(struct rrc_update_state *state, struct rrc
     }
 }
 
-void rrc_update_do_updates(void* xfb)
+void rrc_update_do_updates(void *xfb)
 {
     rrc_con_clear(true);
 
@@ -543,21 +543,23 @@ void rrc_update_do_updates(void* xfb)
     int is_large = rrc_update_is_large(&state, &updates_size);
     RRC_ASSERT(is_large >= 0, "failed to get update size");
 
-    if(is_large == 1)
+    if (is_large == 1)
     {
-        char info_line[128];
-        snprintf(info_line, 128, "There are %i updates available, totalling %iMB of data to download.", state.num_updates, (int)(updates_size/1000/1000));
-        char* lines[] = {
-            info_line,
+        char info_line1[128];
+        char info_line2[128];
+        snprintf(info_line1, 128, "There are %i updates available,", state.num_updates);
+        snprintf(info_line2, 128, "totalling %iMB of data to download.", (int)(updates_size / 1000 / 1000));
+        char *lines[] = {
+            info_line1,
+            info_line2,
             "This may take a long time!",
             "It may be quicker to reinstall the pack from your computer.",
             "",
-            "Would you like to continue?"
-        };
+            "Would you like to continue?"};
 
-        enum rrc_prompt_result result = rrc_prompt_yes_no(xfb, lines, 5);
+        enum rrc_prompt_result result = rrc_prompt_yes_no(xfb, lines, 6);
         RRC_ASSERT(result != RRC_PROMPT_RESULT_ERROR, "failed to generate prompt");
-        if(result == RRC_PROMPT_RESULT_NO)
+        if (result == RRC_PROMPT_RESULT_NO)
         {
             return;
         }

--- a/source/update/update.c
+++ b/source/update/update.c
@@ -31,6 +31,7 @@
 #include "../util.h"
 #include "../console.h"
 #include "../time.h"
+#include "../prompt.h"
 
 #define _RRC_UPDATE_ZIP_NAME "update.zip"
 
@@ -358,6 +359,40 @@ void rrc_update_extract_zip_archive(struct rrc_update_result *res)
     zip_close(archive);
 }
 
+int rrc_update_get_total_update_size(struct rrc_update_state *state, curl_off_t *size)
+{
+    *size = 0;
+
+    for(int i = 0; i < state->num_updates; i++)
+    {
+        int ret;
+        curl_off_t this_size;
+
+        ret = _rrc_update_get_zip_size(state->update_urls[i], &this_size);
+        if(ret != 0)
+        {
+            *size = 0;
+            return -ret;
+        }
+
+        *size += this_size;
+    }
+
+    return 0;
+}
+
+int rrc_update_is_large(struct rrc_update_state *state, curl_off_t *size)
+{
+    int ret = rrc_update_get_total_update_size(state, size);
+
+    if(ret < 0)
+    {
+        return ret;
+    }
+
+    return (*size > RRC_UPDATE_LARGE_THRESHOLD);
+}
+
 void rrc_update_do_updates_with_state(struct rrc_update_state *state, struct rrc_update_result *res)
 {
     res->ecode = RRC_UPDATE_EOK;
@@ -454,7 +489,7 @@ void rrc_update_do_updates_with_state(struct rrc_update_state *state, struct rrc
     }
 }
 
-void rrc_update_do_updates()
+void rrc_update_do_updates(void* xfb)
 {
     rrc_con_clear(true);
 
@@ -503,6 +538,30 @@ void rrc_update_do_updates()
             .current_version = current,
             .num_deleted_files = num_deleted_files,
             .deleted_files = deleted_files};
+
+    curl_off_t updates_size;
+    int is_large = rrc_update_is_large(&state, &updates_size);
+    RRC_ASSERT(is_large >= 0, "failed to get update size");
+
+    if(is_large == 1)
+    {
+        char info_line[128];
+        snprintf(info_line, 128, "There are %i updates available, totalling %iMB of data to download.", state.num_updates, (int)(updates_size/1000/1000));
+        char* lines[] = {
+            info_line,
+            "This may take a long time!",
+            "It may be quicker to reinstall the pack from your computer.",
+            "",
+            "Would you like to continue?"
+        };
+
+        enum rrc_prompt_result result = rrc_prompt_yes_no(xfb, lines, 5);
+        RRC_ASSERT(result != RRC_PROMPT_RESULT_ERROR, "failed to generate prompt");
+        if(result == RRC_PROMPT_RESULT_NO)
+        {
+            return;
+        }
+    }
 
     struct rrc_update_result upres;
     rrc_update_do_updates_with_state(&state, &upres);

--- a/source/update/update.h
+++ b/source/update/update.h
@@ -21,6 +21,7 @@
 
 #include <curl/curl.h>
 
+#define RRC_UPDATE_LARGE_THRESHOLD (long)(1000 * 1000 * 100) /* 100MB */
 #define RRC_VERSIONFILE "RetroRewind6/version.txt"
 
 /* Holds all info related to an update or sequence of updates */
@@ -127,9 +128,23 @@ struct rrc_update_result
 };
 
 /*
-    Convert an error failure code to a string for display.
+    Get the total size of all update ZIPs in bytes. This can be used to determine whether
+    to warn the user that updating will take a long time based on some arbitrary threshold.
+
+    On success, returns 0 and `size' is populated with the total download size. On failure,
+    the return code is negative (usually a cURL error code), and `size' is zero.
 */
-int rrc_update_ecode_to_string(int code);
+int rrc_update_get_total_update_size(struct rrc_update_state *state, curl_off_t *size);
+
+/*
+    Determines if a update or sequence of updates is large. This is determined based on
+    if the total update download size is above some arbitrary value defined in
+    RRC_UPDATE_LARGE_THRESHOLD, in bytes.
+
+    Returns 0 if the update is not large (or there are none), 1 if it is large, and
+    a negative error status on failure.
+*/
+int rrc_update_is_large(struct rrc_update_state *state, curl_off_t *size);
 
 /*
     Does all updates specified in update_urls, in order.
@@ -145,6 +160,6 @@ void rrc_update_do_updates_with_state(struct rrc_update_state *state, struct rrc
 /*
     Checks if updates are needed and download them. See `rrc_update_do_updates_with_state` for more details
 */
-void rrc_update_do_updates();
+void rrc_update_do_updates(void* xfb);
 
 #endif

--- a/source/update/update.h
+++ b/source/update/update.h
@@ -160,6 +160,6 @@ void rrc_update_do_updates_with_state(struct rrc_update_state *state, struct rrc
 /*
     Checks if updates are needed and download them. See `rrc_update_do_updates_with_state` for more details
 */
-void rrc_update_do_updates(void* xfb);
+void rrc_update_do_updates(void *xfb);
 
 #endif


### PR DESCRIPTION
Closes #19 

If an update is more than 100MB, alert the user. Prompt them to cancel and give them the option of reinstalling the entire pack manually.