### PR TITLE
Add "automatic updates" option and mark unsaved changes in settings menu

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -43,6 +43,7 @@
 #include "prompt.h"
 #include "gui.h"
 #include "res.h"
+#include "settingsfile.h"
 
 /* 100ms */
 #define DISKCHECK_DELAY 100000
@@ -158,6 +159,15 @@ int main(int argc, char **argv)
     RRC_ASSERTEQ(res, RRC_LWP_OK, "LWP_JoinThread wiisocket init");
     RRC_ASSERTEQ(wiisocket_res, 0, "wiisocket_init");
 
+    struct rrc_settingsfile stored_settings;
+    RRC_ASSERTEQ(rrc_settingsfile_parse(&stored_settings), RRC_SETTINGSFILE_OK, "failed to parse settingsfile");
+
+    // Check for updates if the user enabled that setting.
+    if (stored_settings.auto_update)
+    {
+        rrc_update_do_updates(xfb);
+    }
+
 #define INTERRUPT_TIME 3000000 /* 3 seconds */
     rrc_con_clear(true);
 
@@ -181,7 +191,7 @@ int main(int argc, char **argv)
 
         if (pressed & RRC_WPAD_PLUS_MASK)
         {
-            switch (rrc_settings_display(xfb))
+            switch (rrc_settings_display(xfb, &stored_settings))
             {
             case RRC_SETTINGS_LAUNCH:
                 goto interrupt_loop_end;

--- a/source/main.c
+++ b/source/main.c
@@ -165,7 +165,8 @@ int main(int argc, char **argv)
     // Check for updates if the user enabled that setting.
     if (stored_settings.auto_update)
     {
-        rrc_update_do_updates(xfb);
+        int update_count;
+        rrc_update_do_updates(xfb, &update_count);
     }
 
 #define INTERRUPT_TIME 3000000 /* 3 seconds */

--- a/source/prompt.c
+++ b/source/prompt.c
@@ -60,7 +60,7 @@ void _rrc_prompt_xfb_setup()
     }
 }
 
-enum rrc_prompt_result _rrc_prompt_2_options(
+enum rrc_prompt_result rrc_prompt_2_options(
     void *old_xfb,
     char **lines,
     int n,
@@ -158,10 +158,10 @@ enum rrc_prompt_result _rrc_prompt_2_options(
 
 enum rrc_prompt_result rrc_prompt_yes_no(void *old_xfb, char **lines, int n)
 {
-    return _rrc_prompt_2_options(old_xfb, lines, n, "Yes", "No", RRC_PROMPT_RESULT_YES, RRC_PROMPT_RESULT_NO);
+    return rrc_prompt_2_options(old_xfb, lines, n, "Yes", "No", RRC_PROMPT_RESULT_YES, RRC_PROMPT_RESULT_NO);
 }
 
 enum rrc_prompt_result rrc_prompt_ok_cancel(void *old_xfb, char **lines, int n)
 {
-    return _rrc_prompt_2_options(old_xfb, lines, n, "OK", "Cancel", RRC_PROMPT_RESULT_OK, RRC_PROMPT_RESULT_CANCEL);
+    return rrc_prompt_2_options(old_xfb, lines, n, "OK", "Cancel", RRC_PROMPT_RESULT_OK, RRC_PROMPT_RESULT_CANCEL);
 }

--- a/source/prompt.h
+++ b/source/prompt.h
@@ -30,11 +30,7 @@ enum rrc_prompt_result
 };
 
 /*
-    Creates a user prompt. All `lines' are printed on the screen in order, centered,
-    and below the user is presented with either `yes' or `no' to select.
-    Each line has a newline appended, you do not need to append them yourself.
-    `lines' is limited to 10 entries. Each line cannot exceed the console line width.
-    `n' contains the amount of lines in `lines'.
+    See `rrc_prompt_2_options' for a description of prompts.
 
     This function returns RRC_PROMPT_RESULT_YES if `Yes' is selected and RRC_PROMPT_RESULT_NO if `No' is selected.
     On error, RRC_PROMPT_RESULT_ERROR is returned.
@@ -42,11 +38,32 @@ enum rrc_prompt_result
 enum rrc_prompt_result rrc_prompt_yes_no(void *old_xfb, char **lines, int n);
 
 /*
-    See `rrc_prompt_yes_no' for a description of prompts.
+    See `rrc_prompt_2_options' for a description of prompts.
 
     This function returns RRC_PROMPT_RESULT_OK if `OK' is selected and RRC_PROMPT_RESULT_CANCEL if `Cancel' is selected.
     On error, RRC_PROMPT_RESULT_ERROR is returned.
 */
 enum rrc_prompt_result rrc_prompt_ok_cancel(void *old_xfb, char **lines, int n);
+
+/**
+    Creates a user prompt. All `lines' are printed on the screen in order, centered,
+    and below the user is presented with either `yes' or `no' to select.
+    Each line has a newline appended, you do not need to append them yourself.
+    `lines' is limited to 10 entries. Each line cannot exceed the console line width.
+    `n' contains the amount of lines in `lines'.
+    `option1' and `option2' are the available buttons to display. `option1_result' and `option2_result'
+    are the values that the buttons map to.
+
+    This function returns option1_result or option2_result depending on which option is selected.
+    On error, RRC_PROMPT_RESULT_ERROR is returned.
+ */
+enum rrc_prompt_result rrc_prompt_2_options(
+    void *old_xfb,
+    char **lines,
+    int n,
+    char *option1,
+    char *option2,
+    enum rrc_prompt_result option1_result,
+    enum rrc_prompt_result option2_result);
 
 #endif

--- a/source/settings.c
+++ b/source/settings.c
@@ -373,16 +373,9 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
                 }
                 else if (entry->label == perform_updates_label)
                 {
-                    char *lines[] = {
-                        "Would you like to update now?"};
-
-                    enum rrc_prompt_result result = rrc_prompt_yes_no(xfb, lines, 1);
-                    if (result == RRC_PROMPT_RESULT_YES)
-                    {
-                        rrc_update_do_updates(xfb);
-                        rrc_con_clear(true);
-                        break;
-                    }
+                    rrc_update_do_updates(xfb);
+                    rrc_con_clear(true);
+                    break;
                 }
                 else if (entry->label == exit_label)
                 {

--- a/source/settings.c
+++ b/source/settings.c
@@ -369,6 +369,7 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
                             entries[i].initial_selected_option = *entries[i].selected_option;
                         }
                     }
+                    break;
                 }
                 else if (entry->label == perform_updates_label)
                 {

--- a/source/settings.h
+++ b/source/settings.h
@@ -20,6 +20,8 @@
 #ifndef RRC_SETTINGS_H
 #define RRC_SETTINGS_H
 
+#include "settingsfile.h"
+
 enum rrc_settings_result
 {
     RRC_SETTINGS_LAUNCH = 0,
@@ -28,6 +30,6 @@ enum rrc_settings_result
 
 // TODO: move xfb to some kind of global descriptor
 
-enum rrc_settings_result rrc_settings_display(void *xfb);
+enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile *stored_settings);
 
 #endif

--- a/source/settingsfile.c
+++ b/source/settingsfile.c
@@ -47,6 +47,7 @@
 #define RRC_SETTINGSFILE_MY_STUFF_KEY "My Stuff"
 #define RRC_SETTINGSFILE_LANGUAGE_KEY "Language"
 #define RRC_SETTINGSFILE_SAVEGAME_KEY "Separate savegame"
+#define RRC_SETTINGSFILE_AUTOUPDATE_KEY "Auto update"
 #define RRC_SETTINGSFILE_MAGIC 1920234103
 #define RRC_SETTINGSFILE_VERSION 0
 
@@ -108,6 +109,7 @@ enum rrc_settingsfile_status rrc_settingsfile_parse(struct rrc_settingsfile *set
     settings->my_stuff = RRC_SETTINGSFILE_DEFAULT;
     settings->language = RRC_SETTINGSFILE_DEFAULT;
     settings->savegame = RRC_SETTINGSFILE_DEFAULT;
+    settings->auto_update = RRC_SETTINGSFILE_DEFAULT;
 
     for (int i = 0; i < entry_count; i++)
     {
@@ -131,17 +133,21 @@ enum rrc_settingsfile_status rrc_settingsfile_parse(struct rrc_settingsfile *set
         read = fread((void *)&value, sizeof(u32), 1, file);
         RRC_ASSERT(read == 1, "failed to read a u32 value");
 
-        if (strcmp(key, "My Stuff") == 0)
+        if (strcmp(key, RRC_SETTINGSFILE_MY_STUFF_KEY) == 0)
         {
             settings->my_stuff = value;
         }
-        else if (strcmp(key, "Language") == 0)
+        else if (strcmp(key, RRC_SETTINGSFILE_LANGUAGE_KEY) == 0)
         {
             settings->language = value;
         }
-        else if (strcmp(key, "Separate savegame") == 0)
+        else if (strcmp(key, RRC_SETTINGSFILE_SAVEGAME_KEY) == 0)
         {
             settings->savegame = value;
+        }
+        else if (strcmp(key, RRC_SETTINGSFILE_AUTOUPDATE_KEY) == 0)
+        {
+            settings->auto_update = value;
         }
     }
 
@@ -168,11 +174,12 @@ enum rrc_settingsfile_status rrc_settingsfile_store(struct rrc_settingsfile *set
     FILE *file = fopen(RRC_SETTINGSFILE_PATH, "w");
     RRC_ASSERT(file != NULL, "failed to open file");
 
-    rrc_settings_file_write_header(file, 3);
+    rrc_settings_file_write_header(file, 4);
 
     rrc_settingsfile_set_option(file, RRC_SETTINGSFILE_MY_STUFF_KEY, settings->my_stuff);
     rrc_settingsfile_set_option(file, RRC_SETTINGSFILE_LANGUAGE_KEY, settings->language);
     rrc_settingsfile_set_option(file, RRC_SETTINGSFILE_SAVEGAME_KEY, settings->savegame);
+    rrc_settingsfile_set_option(file, RRC_SETTINGSFILE_AUTOUPDATE_KEY, settings->auto_update);
 
     fclose(file);
     return RRC_SETTINGSFILE_OK;

--- a/source/settingsfile.c
+++ b/source/settingsfile.c
@@ -109,7 +109,7 @@ enum rrc_settingsfile_status rrc_settingsfile_parse(struct rrc_settingsfile *set
     settings->my_stuff = RRC_SETTINGSFILE_DEFAULT;
     settings->language = RRC_SETTINGSFILE_DEFAULT;
     settings->savegame = RRC_SETTINGSFILE_DEFAULT;
-    settings->auto_update = RRC_SETTINGSFILE_DEFAULT;
+    settings->auto_update = RRC_SETTINGSFILE_AUTOUPDATE_DEFAULT;
 
     for (int i = 0; i < entry_count; i++)
     {

--- a/source/settingsfile.h
+++ b/source/settingsfile.h
@@ -19,6 +19,8 @@
 #ifndef RRC_SETTINGSFILE_H
 #define RRC_SETTINGSFILE_H
 
+#include <gctypes.h>
+
 #define RRC_SETTINGSFILE_DEFAULT 0 /* disabled */
 
 enum rrc_settingsfile_status
@@ -31,9 +33,10 @@ enum rrc_settingsfile_status
 
 struct rrc_settingsfile
 {
-    int my_stuff;
-    int language;
-    int savegame;
+    u32 my_stuff;
+    u32 language;
+    u32 savegame;
+    u32 auto_update;
 };
 
 /**

--- a/source/settingsfile.h
+++ b/source/settingsfile.h
@@ -21,7 +21,8 @@
 
 #include <gctypes.h>
 
-#define RRC_SETTINGSFILE_DEFAULT 0 /* disabled */
+#define RRC_SETTINGSFILE_DEFAULT 0            /* disabled */
+#define RRC_SETTINGSFILE_AUTOUPDATE_DEFAULT 1 /* enabled */
 
 enum rrc_settingsfile_status
 {

--- a/source/update/update.c
+++ b/source/update/update.c
@@ -516,6 +516,17 @@ void rrc_update_do_updates(void *xfb)
         RRC_FATAL("couldnt get necessary download urls! res: %i\n", res);
     }
 
+    if (count > 0)
+    {
+        char *lines[] = {"An update is available."};
+
+        enum rrc_prompt_result result = rrc_prompt_2_options(xfb, lines, 1, "Update", "Skip", RRC_PROMPT_RESULT_YES, RRC_PROMPT_RESULT_NO);
+        if (result == RRC_PROMPT_RESULT_NO)
+        {
+            return;
+        }
+    }
+
     res = rrc_versionsfile_get_removed_files(&deleted_versionsfile);
     if (res < 0)
     {

--- a/source/update/update.h
+++ b/source/update/update.h
@@ -158,8 +158,9 @@ int rrc_update_is_large(struct rrc_update_state *state, curl_off_t *size);
 void rrc_update_do_updates_with_state(struct rrc_update_state *state, struct rrc_update_result *res);
 
 /*
-    Checks if updates are needed and download them. See `rrc_update_do_updates_with_state` for more details
+    Checks if updates are needed, and if there are, prompt the user and and download them. See `rrc_update_do_updates_with_state` for more details.
+    This also writes the number of available updates into `count' and returns whether the updates were actually installed.
 */
-void rrc_update_do_updates(void *xfb);
+bool rrc_update_do_updates(void *xfb, int *count);
 
 #endif


### PR DESCRIPTION
- Add an "automatic updates" setting to the settings menu and the file, that is checked on startup and when enabled will run the logic for checking for updates and downloading them
- Mark unsaved changes with a `*` and show a prompt when exiting/launching
- Small refactor to the settings file (renamed "option" to "entry" because that word was used for two different things in this file)