### PR TITLE
Compile in CI

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,0 +1,7 @@
+# Dockerfile for the bare environment RR needs (dkp tools & necessary libraries installed into /opt). Used in CI
+
+FROM devkitpro/devkitppc
+
+COPY install-libs.sh ./
+
+RUN ./install-libs.sh

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,36 @@
+name: Check
+on:
+  - push
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker image cache
+        uses: actions/cache@v4
+        id: toolchain-cache
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-docker-${{ hashFiles('install-libs.sh') }}
+
+      - name: Prepare docker image
+        run: |
+          docker buildx create --name builder --driver docker-container --use
+          docker buildx inspect --bootstrap
+
+          docker buildx build . -f .github/docker/Dockerfile \
+            --builder builder \
+            --cache-from=type=local,src=/tmp/.buildx-cache \
+            --cache-to=type=local,dest=/tmp/.buildx-cache \
+            -t retrorewind --load
+
+      - name: Compile project
+        run: |
+          docker run --rm -i -d -v $(pwd)/:/rr -w /rr --name retrorewind-ci retrorewind bash
+          docker exec retrorewind-ci make clean
+          docker exec retrorewind-ci make
+          docker stop retrorewind-ci

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,7 @@
 name: Check
 on:
   - push
+  - pull_request
 
 jobs:
   check:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,7 @@
 name: Check
 on:
-  - push
-  - pull_request
+  push:
+  pull_request:
 
 jobs:
   check:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ In order to build this project, you need:
 - [DevkitPro](https://devkitpro.org/wiki/Getting_Started), specifically all packages in the `wii-dev` and `ppc-dev` groups.
 - Additional libraries: libcurl (the `install-libs.sh` script can install them for you)
 
-This project uses a `Makefile` for building the project: running `make` in the root directory will build the project and produce a `RR-Launcher.dol` file,
-which is the compiled channel that can then be run.
+This project uses a `Makefile` for building the project: running `make` in the root directory will build the project and produce a `RR-Launcher.dol` file.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is an experimental channel for Wii, Wii U and Dolphin to launch and manage 
 ### Motivation
 
 This channel is set to replace the existing Riivolution-based launcher. It solves a number of issues with that launcher:
+
 - It is very overengineered and contains many unused features,
 - It takes a long time to initially load,
 - It is diffiult and time consuming to maintain,
@@ -15,6 +16,16 @@ In addition, a new channel would allow us to add novel features such as a quick 
 ### Technical Details
 
 The best way to understand this channel on a technical level is to read the source code, as a lot of it is documented. Wiibrew is also a fantastic resource regarding all things Wii homebrew: https://wiibrew.org/
+
+### Building
+
+In order to build this project, you need:
+
+- [DevkitPro](https://devkitpro.org/wiki/Getting_Started), specifically all packages in the `wii-dev` and `ppc-dev` groups.
+- Additional libraries: libcurl (the `install-libs.sh` script can install them for you)
+
+This project uses a `Makefile` for building the project: running `make` in the root directory will build the project and produce a `RR-Launcher.dol` file,
+which is the compiled channel that can then be run.
 
 ### License
 

--- a/install-libs.sh
+++ b/install-libs.sh
@@ -1,0 +1,18 @@
+set -e
+
+WIICURL='https://github.com/AndrewPiroli/wii-curl/releases/download/c8.12.1%2Bm3.6.2/wii-curl-8.12.1-1-any.pkg.tar.gz'
+WIISOCKET='https://github.com/AndrewPiroli/wii-curl/releases/download/c8.12.1%2Bm3.6.2/libwiisocket-0.1-1-any.pkg.tar.gz'
+WIIMBEDTLS='https://github.com/AndrewPiroli/wii-curl/releases/download/c8.12.1%2Bm3.6.2/wii-mbedtls-3.6.2-2-any.pkg.tar.gz'
+
+mkdir /tmp/libs-temp-install
+cd /tmp/libs-temp-install
+
+wget $WIICURL
+wget $WIISOCKET
+wget $WIIMBEDTLS
+
+tar -xvf wii-curl-8.12.1-1-any.pkg.tar.gz
+tar -xvf wii-mbedtls-3.6.2-2-any.pkg.tar.gz
+tar -xvf libwiisocket-0.1-1-any.pkg.tar.gz
+
+rsync -av --remove-source-files opt/devkitpro/ /opt/devkitpro/


### PR DESCRIPTION
Makes sure that the project always cleanly compiles by compiling it in ci. The dkp packages can't be installed the usual way via pacman because they block gh actions IPs, so this uses their docker images, which is also how they recommend you do it.