### PR TITLE
Migrate settingsfile & updater error handling to new result type

### DIFF
--- a/source/console.c
+++ b/source/console.c
@@ -132,11 +132,8 @@ void rrc_con_display_splash()
 
     if (cached_version == -1)
     {
-        cached_version = rrc_update_get_current_version();
-        if (cached_version < 0)
-        {
-            RRC_FATAL("failed to get version: ret = %i", cached_version);
-        }
+        struct rrc_result version_result = rrc_update_get_current_version(&cached_version);
+        rrc_result_error_check_error_fatal(&version_result);
     }
 
     char vertext[32];

--- a/source/main.c
+++ b/source/main.c
@@ -195,7 +195,9 @@ int main(int argc, char **argv)
     if (stored_settings.auto_update)
     {
         int update_count;
-        rrc_update_do_updates(xfb, &update_count);
+        bool any_updates;
+        struct rrc_result update_res = rrc_update_do_updates(xfb, &update_count, &any_updates);
+        rrc_result_error_check_error_normal(&update_res, xfb);
     }
 
 #define INTERRUPT_TIME 3000000 /* 3 seconds */

--- a/source/result.c
+++ b/source/result.c
@@ -73,6 +73,26 @@ struct rrc_result rrc_result_create_error_corrupted_settingsfile(const char *con
     return res;
 }
 
+struct rrc_result rrc_result_create_error_corrupted_versionfile(const char *context)
+{
+    struct rrc_result res;
+
+    res.errtype = ESOURCE_CORRUPTED_VERSIONFILE;
+    res.context = context;
+
+    return res;
+}
+
+struct rrc_result rrc_result_create_error_misc_update(const char *context)
+{
+    struct rrc_result res;
+
+    res.errtype = ESOURCE_UPDATE_MISC;
+    res.context = context;
+
+    return res;
+}
+
 bool rrc_result_is_error(struct rrc_result *result)
 {
     return result != NULL && result->errtype != ESOURCE_NONE;
@@ -92,9 +112,13 @@ char *rrc_result_strerror(struct rrc_result *result)
     case ESOURCE_ERRNO:
         return strerror(result->inner.errnocode);
     case ESOURCE_ZIP:
-        return "TODO: We didn't implement this yet";
+        return "ZIP file error.";
     case ESOURCE_CORRUPTED_SETTINGSFILE:
         return "Corrupted settings file detected.";
+    case ESOURCE_CORRUPTED_VERSIONFILE:
+        return "Corrupted version file detected.";
+    case ESOURCE_UPDATE_MISC:
+        return "Update failed.";
     default:
         return NULL;
     }

--- a/source/result.c
+++ b/source/result.c
@@ -26,15 +26,9 @@
 
 #include "console.h"
 
-struct rrc_result rrc_result_create_success()
-{
-    struct rrc_result res;
-
-    res.errtype = ESOURCE_NONE;
-    res.context = NULL;
-
-    return res;
-}
+const struct rrc_result rrc_result_success = {
+    .errtype = ESOURCE_NONE,
+};
 
 struct rrc_result rrc_result_create_error_curl(CURLcode error, const char *context)
 {
@@ -69,6 +63,16 @@ struct rrc_result rrc_result_create_error_zip(int error, const char *context)
     return res;
 }
 
+struct rrc_result rrc_result_create_error_corrupted_settingsfile(const char *context)
+{
+    struct rrc_result res;
+
+    res.errtype = ESOURCE_CORRUPTED_SETTINGSFILE;
+    res.context = context;
+
+    return res;
+}
+
 bool rrc_result_is_error(struct rrc_result *result)
 {
     return result != NULL && result->errtype != ESOURCE_NONE;
@@ -89,6 +93,8 @@ char *rrc_result_strerror(struct rrc_result *result)
         return strerror(result->inner.errnocode);
     case ESOURCE_ZIP:
         return "TODO: We didn't implement this yet";
+    case ESOURCE_CORRUPTED_SETTINGSFILE:
+        return "Corrupted settings file detected.";
     default:
         return NULL;
     }

--- a/source/result.h
+++ b/source/result.h
@@ -38,7 +38,9 @@ enum rrc_result_error_source
     /* Corruption detected in settingsfile during parsing.
        This should ideally never happen unless the user manually edited it and the detection is only a best-effort,
        but if we do detect it we can ask the user if they want to reset the file to its defaults. */
-    ESOURCE_CORRUPTED_SETTINGSFILE
+    ESOURCE_CORRUPTED_SETTINGSFILE,
+    ESOURCE_UPDATE_MISC,
+    ESOURCE_CORRUPTED_VERSIONFILE
 };
 
 /* Because each library uses their own set of error codes, we need to support all
@@ -113,6 +115,10 @@ struct rrc_result rrc_result_create_error_errno(int eno, const char *context);
 struct rrc_result rrc_result_create_error_zip(int error, const char *context);
 
 struct rrc_result rrc_result_create_error_corrupted_settingsfile(const char *context);
+
+struct rrc_result rrc_result_create_error_corrupted_versionfile(const char *context);
+
+struct rrc_result rrc_result_create_error_misc_update(const char *context);
 
 /* Returns true if this result is an error, false otherwise. */
 bool rrc_result_is_error(struct rrc_result *result);

--- a/source/settings.c
+++ b/source/settings.c
@@ -366,14 +366,17 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
                 {
                     if (has_unsaved_changes && prompt_save_unsaved_changes(xfb, entries, entry_count))
                     {
-                        RRC_ASSERTEQ(rrc_settingsfile_store(stored_settings), RRC_SETTINGSFILE_OK, "failed to save changes");
+                        struct rrc_result res = rrc_settingsfile_store(stored_settings);
+                        rrc_result_error_check_error_normal(&res, xfb);
                     }
 
                     goto launch;
                 }
                 else if (entry->label == save_label)
                 {
-                    RRC_ASSERTEQ(rrc_settingsfile_store(stored_settings), RRC_SETTINGSFILE_OK, "failed to save changes");
+                    struct rrc_result res = rrc_settingsfile_store(stored_settings);
+                    rrc_result_error_check_error_normal(&res, xfb);
+
                     for (int i = 0; i < entry_count; i++)
                     {
                         if (entries[i].type == ENTRY_TYPE_SELECT)
@@ -405,7 +408,8 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
                 {
                     if (has_unsaved_changes && prompt_save_unsaved_changes(xfb, entries, entry_count))
                     {
-                        RRC_ASSERTEQ(rrc_settingsfile_store(stored_settings), RRC_SETTINGSFILE_OK, "failed to save changes");
+                        struct rrc_result res = rrc_settingsfile_store(stored_settings);
+                        rrc_result_error_check_error_normal(&res, xfb);
                     }
 
                     goto exit;

--- a/source/settings.c
+++ b/source/settings.c
@@ -391,17 +391,27 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
                 else if (entry->label == perform_updates_label)
                 {
                     int update_count;
-                    bool updated = rrc_update_do_updates(xfb, &update_count);
-                    if (update_count == 0)
+                    bool updated;
+                    struct rrc_result update_res = rrc_update_do_updates(xfb, &update_count, &updated);
+
+                    if (rrc_result_is_error(&update_res))
                     {
-                        strncpy(status_message, "No updates available.", sizeof(status_message));
+                        rrc_result_error_check_error_normal(&update_res, xfb);
                     }
-                    else if (updated)
+                    else
                     {
-                        snprintf(status_message, sizeof(status_message), "%d updates installed.", update_count);
+                        if (update_count == 0)
+                        {
+                            strncpy(status_message, "No updates available.", sizeof(status_message));
+                        }
+                        else if (updated)
+                        {
+                            snprintf(status_message, sizeof(status_message), "%d updates installed.", update_count);
+                        }
+
+                        rrc_con_clear(true);
                     }
 
-                    rrc_con_clear(true);
                     break;
                 }
                 else if (entry->label == exit_label)

--- a/source/settingsfile.h
+++ b/source/settingsfile.h
@@ -20,6 +20,7 @@
 #define RRC_SETTINGSFILE_H
 
 #include <gctypes.h>
+#include "result.h"
 
 #define RRC_SETTINGSFILE_DEFAULT 0            /* disabled */
 #define RRC_SETTINGSFILE_AUTOUPDATE_DEFAULT 1 /* enabled */
@@ -41,14 +42,20 @@ struct rrc_settingsfile
 };
 
 /**
+ * Creates a settingsfile on the SD card.
+ */
+struct rrc_result rrc_settingsfile_create();
+
+/**
  * Initializes an `rrc_settingsfile` by reading it from the sd card.
  * If it does not already exist, this function will create it and initialize the file with default values.
+ * The settings pointee will always be fully initialized, even in case of an error (in which case it will have default values).
  */
-enum rrc_settingsfile_status rrc_settingsfile_parse(struct rrc_settingsfile *settings);
+struct rrc_result rrc_settingsfile_parse(struct rrc_settingsfile *settings);
 
 /**
  * Writes an `rrc_settingsfile` to the sd card.
  */
-enum rrc_settingsfile_status rrc_settingsfile_store(struct rrc_settingsfile *settings);
+struct rrc_result rrc_settingsfile_store(struct rrc_settingsfile *settings);
 
 #endif

--- a/source/update/update.h
+++ b/source/update/update.h
@@ -65,57 +65,6 @@ struct rrc_result rrc_update_set_current_version(int version);
 */
 struct rrc_result rrc_update_download_zip(char *url, char *filename, int current_zip, int max_zips);
 
-enum rrc_update_ecode
-{
-    /* Success */
-    RRC_UPDATE_EOK = 0,
-
-    /* CURL error. `ccode' is set to that error if this is set. */
-    RRC_UPDATE_ECURL,
-
-    /* IO Errors */
-    /* Could not open file */
-    RRC_UPDATE_INVFILE,
-    /* Failed to create directories for file */
-    RRC_UPDATE_EMKDIR,
-    /* Failed to open/create output file for the extracted file. */
-    RRC_UPDATE_EOPEN_OUTFILE,
-    /* Failed to open or stat file in zip archive. */
-    RRC_UPDATE_EOPEN_AR_FILE,
-    /* Failed to read archive file contents. */
-    RRC_UPDATE_EREAD_AR,
-    /* Failed to write archive contents into output file on SD card. */
-    RRC_UPDATE_EWRITE_OUT,
-    /* Failed to write version.txt file. */
-    RRC_UPDATE_EWRITE_VERSION,
-    /* Failed to get free space on SD card */
-    RRC_UPDATE_ESD_SZ,
-    /* Not enough space on SD card to download ZIP */
-    RRC_UPDATE_EZIP_SPC,
-    /* Not enough space on SD card to extract ZIP */
-    RRC_UPDATE_EZIP_EX_SPC,
-
-    /* ZIP Errors */
-    /* Failed to open the downloaded update ZIP file */
-    RRC_UPDATE_EOPEN_ZIP
-};
-
-typedef union
-{
-    /* defined if ecode == ECURL */
-    CURLcode ccode;
-    /* defined for IO errors except INVFILE */
-    int errnocode;
-    /* defined for ZIP errors */
-    int ziperr;
-} rrc_update_result_inner;
-
-struct rrc_update_result
-{
-    enum rrc_update_ecode ecode;
-    rrc_update_result_inner inner;
-};
-
 /*
     Get the total size of all update ZIPs in bytes. This can be used to determine whether
     to warn the user that updating will take a long time based on some arbitrary threshold.

--- a/source/update/update.h
+++ b/source/update/update.h
@@ -20,6 +20,7 @@
 #define RRC_UPDATE_H
 
 #include <curl/curl.h>
+#include "../result.h"
 
 #define RRC_UPDATE_LARGE_THRESHOLD (long)(1000 * 1000 * 100) /* 100MB */
 #define RRC_VERSIONFILE "RetroRewind6/version.txt"
@@ -48,33 +49,21 @@ struct rrc_update_state
 /*
     Returns an int specifying version information from version.txt.
     E.g., 4.2.0 = 420
-    Returns negative status on failure.
     SD driver must be loaded for this to work.
 */
-int rrc_update_get_current_version();
+struct rrc_result rrc_update_get_current_version(int *version);
 
 /*
     Writes the specified version int into version.txt.
-    Returns negative status on failure.
     SD driver must be loaded for this to work.
 */
-int rrc_update_set_current_version(int version);
+struct rrc_result rrc_update_set_current_version(int version);
 
 /*
     Downloads a Retro Rewind ZIP. Uses the console to display progress.
     Stores on SD in the file given by `filename'.
-
-    Returns 0 on success, negative CURLcode status on error.
 */
-int rrc_update_download_zip(char *url, char *filename, int current_zip, int max_zips);
-
-/*
-    Check for updates. If there are updates, the return code is 0 and `ret' is populated with
-    URL information and amount of updates.
-    If there are no updates, `ret' will be NULL and the return code will be 0.
-    On failure, `ret' will be NULL and the return code will be negative.
-*/
-int rrc_update_check_for_updates(struct rrc_update_state *ret);
+struct rrc_result rrc_update_download_zip(char *url, char *filename, int current_zip, int max_zips);
 
 enum rrc_update_ecode
 {
@@ -155,12 +144,12 @@ int rrc_update_is_large(struct rrc_update_state *state, curl_off_t *size);
     Returns 0 on success and a negative code on fail.
     `res' is a pointer to a valid `struct rrc_update_result' on return.
 */
-void rrc_update_do_updates_with_state(struct rrc_update_state *state, struct rrc_update_result *res);
+struct rrc_result rrc_update_do_updates_with_state(struct rrc_update_state *state);
 
 /*
     Checks if updates are needed, and if there are, prompt the user and and download them. See `rrc_update_do_updates_with_state` for more details.
     This also writes the number of available updates into `count' and returns whether the updates were actually installed.
 */
-bool rrc_update_do_updates(void *xfb, int *count);
+struct rrc_result rrc_update_do_updates(void *xfb, int *count, bool *any_updates_installed);
 
 #endif

--- a/source/update/versionsfile.c
+++ b/source/update/versionsfile.c
@@ -30,7 +30,7 @@
 // max array size
 #define _RRC_SPLIT_LIM 4096
 
-int rrc_versionsfile_parse_verstring(char *verstring)
+struct rrc_result rrc_versionsfile_parse_verstring(char *verstring, int *version)
 {
     /* major, minor, revision */
     int parts[3] = {0, 0, 0};
@@ -43,8 +43,10 @@ int rrc_versionsfile_parse_verstring(char *verstring)
         {
             int sect_len = i - started_at;
             if (sect_len == 0)
+            {
                 /* ??? */
-                return -1;
+                return rrc_result_create_error_corrupted_versionfile("Invalid format");
+            }
 
             /* read this section */
             char section[sect_len + 1];
@@ -74,7 +76,8 @@ int rrc_versionsfile_parse_verstring(char *verstring)
     final += (parts[1] * 10);
     final += parts[2];
 
-    return final;
+    *version = final;
+    return rrc_result_success;
 }
 
 struct ptr_len_pair
@@ -264,7 +267,7 @@ void rrc_versionsfile_free_split(char **array, int count)
     free(array);
 }
 
-int rrc_versionsfile_get_necessary_urls_and_versions(char *versionsfile, int current_version, int *uamt, char ***urls, int **versions)
+struct rrc_result rrc_versionsfile_get_necessary_urls_and_versions(char *versionsfile, int current_version, int *uamt, char ***urls, int **versions)
 {
     /*
         We need to read the file line-wise and also space-wise.
@@ -285,15 +288,12 @@ int rrc_versionsfile_get_necessary_urls_and_versions(char *versionsfile, int cur
     int res = rrc_versionsfile_split_by(versionsfile, '\n', &lines, &count);
     if (res < 0)
     {
-        // TODO: report these errors better
-        printf("failed to split versionfile: ret = %i\n", res);
-        return res;
+        return rrc_result_create_error_corrupted_versionfile("Failed to split versionfile");
     }
     else if (res == 2)
     {
-        printf("versionfile had greater than 4096 entries!!! corrupted file?\n");
         rrc_versionsfile_free_split(lines, count);
-        return -1;
+        return rrc_result_create_error_corrupted_versionfile("Versionfile had more than 4096 entries");
     }
 
     int update_idx = 0;
@@ -310,19 +310,17 @@ int rrc_versionsfile_get_necessary_urls_and_versions(char *versionsfile, int cur
 
         if (res < 0)
         {
-            // TODO: report these errors better
-            printf("failed to split versionfile: ret = %i\n", res);
             rrc_versionsfile_free_split(lines, count);
-            return res;
+            return rrc_result_create_error_corrupted_versionfile("Failed to split versionfile");
         }
 
-        int verint = rrc_versionsfile_parse_verstring(parts[0]);
+        int verint;
+        struct rrc_result verstring_res = rrc_versionsfile_parse_verstring(parts[0], &verint);
 
-        if (verint == -1)
+        if (rrc_result_is_error(&verstring_res))
         {
             rrc_versionsfile_free_split(lines, count);
-            /* give this unique error code */
-            return -3;
+            return verstring_res;
         }
 
         if (verint > current_version)
@@ -348,10 +346,10 @@ int rrc_versionsfile_get_necessary_urls_and_versions(char *versionsfile, int cur
     *uamt = update_idx;
 
     rrc_versionsfile_free_split(lines, count);
-    return 0;
+    return rrc_result_success;
 }
 
-int rrc_versionsfile_parse_deleted_files(char *input, int current_version, struct rrc_versionsfile_deleted_file **output, int *amt)
+struct rrc_result rrc_versionsfile_parse_deleted_files(char *input, int current_version, struct rrc_versionsfile_deleted_file **output, int *amt)
 {
     *output = malloc(sizeof(struct rrc_versionsfile_deleted_file) * _RRC_SPLIT_LIM);
     int output_idx = 0;
@@ -361,15 +359,12 @@ int rrc_versionsfile_parse_deleted_files(char *input, int current_version, struc
     int res = rrc_versionsfile_split_by(input, '\n', &lines, &count);
     if (res < 0)
     {
-        // TODO: report these errors better
-        printf("failed to split deleted versionfile: ret = %i\n", res);
-        return res;
+        return rrc_result_create_error_corrupted_versionfile("Failed to split deleted versionfile");
     }
     else if (res == 2)
     {
-        printf("delete versionfile had greater than 4096 entries!!! corrupted file?\n");
         rrc_versionsfile_free_split(lines, count);
-        return -1;
+        return rrc_result_create_error_corrupted_versionfile("Deleted versionfile had more than 4096 entries");
     }
 
     for (int i = 0; i < count; i++)
@@ -379,17 +374,16 @@ int rrc_versionsfile_parse_deleted_files(char *input, int current_version, struc
         res = rrc_versionsfile_split_by(lines[i], ' ', &parts, &parts_count);
         if (res < 0)
         {
-            printf("failed to split deleted versionfile line: ret = %i\n", res);
-            return res;
+            return rrc_result_create_error_corrupted_versionfile("Failed to split deleted versionfile");
         }
 
-        int verint = rrc_versionsfile_parse_verstring(parts[0]);
+        int verint;
+        struct rrc_result verstring_res = rrc_versionsfile_parse_verstring(parts[0], &verint);
 
-        if (verint == -1)
+        if (rrc_result_is_error(&verstring_res))
         {
             rrc_versionsfile_free_split(lines, count);
-            /* give this unique error code */
-            return -3;
+            return verstring_res;
         }
 
         if (verint > current_version)
@@ -412,5 +406,5 @@ int rrc_versionsfile_parse_deleted_files(char *input, int current_version, struc
 
     *amt = output_idx;
     rrc_versionsfile_free_split(lines, count);
-    return 0;
+    return rrc_result_success;
 }

--- a/source/update/versionsfile.h
+++ b/source/update/versionsfile.h
@@ -19,6 +19,8 @@
 #ifndef RRC_VERSIONSFILE_H
 #define RRC_VERSIONSFILE_H
 
+#include "../result.h"
+
 struct rrc_versionsfile_deleted_file
 {
     int version;
@@ -42,9 +44,8 @@ void rrc_versionsfile_free_split(char **array, int count);
 /*
     Returns an int specifying version information from a verstring.
     E.g., 4.2.0 = 420
-    Returns -1 on failure.
 */
-int rrc_versionsfile_parse_verstring(char *verstring);
+struct rrc_result rrc_versionsfile_parse_verstring(char *verstring, int *version);
 
 /*
     Get version information from Retro Rewind servers.
@@ -63,10 +64,9 @@ int rrc_versionsfile_get_removed_files(char **result);
 /*
     Get an array of all URLs we need to download, where the first index needs downloading first.
     On success, return code is 0 and `result' is populated with an array of strings and `count' is set to the amount of entries.
-    On failure, return code is a negative code, `result' is NULL, and `count' is 0.
 */
-int rrc_versionsfile_get_necessary_urls_and_versions(char *versionsfile, int current_version, int *count, char ***result, int **versions);
+struct rrc_result rrc_versionsfile_get_necessary_urls_and_versions(char *versionsfile, int current_version, int *count, char ***result, int **versions);
 
-int rrc_versionsfile_parse_deleted_files(char *input, int current_version, struct rrc_versionsfile_deleted_file **output, int *amt);
+struct rrc_result rrc_versionsfile_parse_deleted_files(char *input, int current_version, struct rrc_versionsfile_deleted_file **output, int *amt);
 
 #endif

--- a/source/util.c
+++ b/source/util.c
@@ -19,6 +19,7 @@
 
 #include <gctypes.h>
 #include <sys/statvfs.h>
+#include "result.h"
 
 u32 align_down(u32 num, u32 align_as)
 {
@@ -30,14 +31,15 @@ u32 align_up(u32 num, u32 align_as)
     return (num + align_as - 1) & -align_as;
 }
 
-unsigned long sd_get_free_space()
+struct rrc_result sd_get_free_space(unsigned long *res)
 {
     struct statvfs sbx;
     int rr = statvfs("/dev/sd", &sbx);
     if (rr != 0)
     {
-        return -1;
+        return rrc_result_create_error_errno(errno, "Failed to get free space on SD card");
     }
 
-    return (unsigned long)(sbx.f_bavail * sbx.f_frsize);
+    *res = sbx.f_bavail * sbx.f_frsize;
+    return rrc_result_success;
 }

--- a/source/util.h
+++ b/source/util.h
@@ -105,9 +105,8 @@
 u32 align_down(u32 num, u32 align_as);
 u32 align_up(u32 num, u32 align_as);
 /*
-    Returns amount of free space on sd card as bytes, or -1 on error.
-    Use errno to inspect errors.
+    Returns amount of free space on sd card as bytes.
 */
-unsigned long sd_get_free_space();
+struct rrc_result sd_get_free_space(unsigned long *res);
 
 #endif


### PR DESCRIPTION
The updater code used to have its own result type. This removes that and changes it to the more general result type.
It also improves the error handling in the settingsfile, and will ask to recreate the file if it's corrupt or other non-fatal errors happen.