### PR TITLE
Fix loading for all PAL video modes

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -9,15 +9,16 @@
                 "/opt/devkitpro/portlibs/ppc/include",
                 "/opt/devkitpro/portlibs/wii/include",
                 "/opt/devkitpro/devkitPPC/powerpc-eabi/include",
-                "/opt/devkitpro/bslug/include",
+                "/opt/devkitpro/bslug/include"
             ],
             "defines": [],
-            "compilerPath": "/usr/bin/clang",
+            "compilerPath": "/usr/bin/gcc",
             "cStandard": "c17",
             "cppStandard": "c++14",
             "intelliSenseMode": "linux-clang-x64",
             "compilerArgs": [
-                "-DPATCH_DOL_LEN=0"
+                "-DPATCH_DOL_LEN=0",
+                "-DHW_RVL"
             ]
         }
     ],

--- a/source/gui.c
+++ b/source/gui.c
@@ -147,35 +147,5 @@ void _rrc_gui_set_mm_video_mode(int mode)
 
 GXRModeObj *rrc_gui_get_video_mode()
 {
-    int confvideo = CONF_GetVideo();
-    bool isprogressive = CONF_GetProgressiveScan() == true;
-    bool havecomponent = VIDEO_HaveComponentCable() == true;
-    bool iseurgb60 = CONF_GetEuRGB60() == true;
-    GXRModeObj *rmode;
-
-    if (confvideo == CONF_VIDEO_PAL)
-    {
-        if (isprogressive && havecomponent)
-        {
-            rmode = &TVEurgb60Hz480Prog;
-            _rrc_gui_set_mm_video_mode(VI_EURGB60);
-        }
-        else if (iseurgb60)
-        {
-            rmode = &TVEurgb60Hz480IntDf;
-            _rrc_gui_set_mm_video_mode(VI_EURGB60);
-        }
-        else
-        {
-            rmode = &TVPal528IntDf;
-            _rrc_gui_set_mm_video_mode(VI_PAL);
-        }
-    }
-    else
-    {
-        rmode = (isprogressive && havecomponent ? &TVNtsc480Prog : &TVNtsc480IntDf);
-        _rrc_gui_set_mm_video_mode(confvideo == CONF_VIDEO_NTSC ?  VI_NTSC : VI_MPAL);
-    }
-
-    return rmode;
+    return VIDEO_GetPreferredMode(NULL);
 }

--- a/source/gui.c
+++ b/source/gui.c
@@ -17,10 +17,10 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <gccore.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "gui.h"
 #include "pngu/pngu.h"
 #include "util.h"
 
@@ -36,7 +36,7 @@ void rrc_gui_xfb_alloc(void **xfb, bool sys_stdio_report)
 
     // Obtain the preferred video mode from the system
     // This will correspond to the settings in the Wii menu
-    GXRModeObj *rmode = VIDEO_GetPreferredMode(NULL);
+    GXRModeObj *rmode = rrc_gui_get_video_mode();
     // Allocate memory for the display in the uncached region
     *xfb = MEM_K0_TO_K1(SYS_AllocateFramebuffer(rmode));
 
@@ -47,7 +47,7 @@ void rrc_gui_xfb_alloc(void **xfb, bool sys_stdio_report)
 
 void rrc_gui_display_con(void *xfb, bool clear_console)
 {
-    GXRModeObj *rmode = VIDEO_GetPreferredMode(NULL);
+    GXRModeObj *rmode = rrc_gui_get_video_mode();
 
     // Set up the video registers with the chosen mode
     VIDEO_Configure(rmode);
@@ -55,6 +55,7 @@ void rrc_gui_display_con(void *xfb, bool clear_console)
     VIDEO_SetNextFramebuffer(xfb);
     // Make the display visible
     VIDEO_SetBlack(false);
+    VIDEO_ClearFrameBuffer(rmode, xfb, COLOR_BLACK);
     // Flush the video register changes to the hardware
     VIDEO_Flush();
     // Wait for Video setup to complete
@@ -132,7 +133,49 @@ out:
 
 int rrc_gui_display_banner(void *xfb)
 {
-    GXRModeObj *rmode = VIDEO_GetPreferredMode(NULL);
+    GXRModeObj *rmode = rrc_gui_get_video_mode();
     extern char banner4_3[];
     return _rrc_gui_draw_banner(xfb, banner4_3, rmode);
+}
+
+/* set video mode in appropriate memory map value */
+void _rrc_gui_set_mm_video_mode(int mode)
+{
+    *((u32 *)0x800000CC) = mode;
+    rrc_invalidate_cache((void *)0x800000CC, 1);
+}
+
+GXRModeObj *rrc_gui_get_video_mode()
+{
+    int confvideo = CONF_GetVideo();
+    bool isprogressive = CONF_GetProgressiveScan() == true;
+    bool havecomponent = VIDEO_HaveComponentCable() == true;
+    bool iseurgb60 = CONF_GetEuRGB60() == true;
+    GXRModeObj *rmode;
+
+    if (confvideo == CONF_VIDEO_PAL)
+    {
+        if (isprogressive && havecomponent)
+        {
+            rmode = &TVEurgb60Hz480Prog;
+            _rrc_gui_set_mm_video_mode(VI_EURGB60);
+        }
+        else if (iseurgb60)
+        {
+            rmode = &TVEurgb60Hz480IntDf;
+            _rrc_gui_set_mm_video_mode(VI_EURGB60);
+        }
+        else
+        {
+            rmode = &TVPal528IntDf;
+            _rrc_gui_set_mm_video_mode(VI_PAL);
+        }
+    }
+    else
+    {
+        rmode = (isprogressive && havecomponent ? &TVNtsc480Prog : &TVNtsc480IntDf);
+        _rrc_gui_set_mm_video_mode(confvideo == CONF_VIDEO_NTSC ?  VI_NTSC : VI_MPAL);
+    }
+
+    return rmode;
 }

--- a/source/gui.h
+++ b/source/gui.h
@@ -17,6 +17,11 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#ifndef RRC_GUI_H
+#define RRC_GUI_H
+
+#include <gccore.h>
+
 /*
     Initialises the main GUI.
 
@@ -47,3 +52,12 @@ void rrc_gui_display_con(void *xfb, bool clear_console);
     Returns 0 status code n success, -1 on error.
 */
 int rrc_gui_display_banner(void *xfb);
+
+/*
+    Using the preferred video mode seems to not work for some configurations.
+
+    Define our own subset of supported resolutions.
+*/
+GXRModeObj* rrc_gui_get_video_mode();
+
+#endif

--- a/source/prompt.c
+++ b/source/prompt.c
@@ -37,14 +37,14 @@ static void *prompt_xfb = NULL;
 
 void _rrc_prompt_alloc_xfb()
 {
-    GXRModeObj *rmode = VIDEO_GetPreferredMode(NULL);
+    GXRModeObj *rmode = rrc_gui_get_video_mode();
     prompt_xfb = MEM_K0_TO_K1(SYS_AllocateFramebuffer(rmode));
     CON_Init(prompt_xfb, 0, 0, rmode->fbWidth, rmode->xfbHeight, rmode->fbWidth * VI_DISPLAY_PIX_SZ);
 }
 
 void _rrc_prompt_reinit_xfb()
 {
-    GXRModeObj *rmode = VIDEO_GetPreferredMode(NULL);
+    GXRModeObj *rmode = rrc_gui_get_video_mode();
     CON_Init(prompt_xfb, 0, 0, rmode->fbWidth, rmode->xfbHeight, rmode->fbWidth * VI_DISPLAY_PIX_SZ);
 }
 


### PR DESCRIPTION
Fixes #45 

Changes video configuration to not use preferred mode and instead pick one of a set of predetermined video modes. This enables launching of the game for all video modes.

Also fixes up the vscode configuration as an aside.