### PR TITLE
Misc improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,12 +116,14 @@ export OUTPUT	:=	$(CURDIR)/$(TARGET)
 
 #---------------------------------------------------------------------------------
 $(BUILD):
+	make --no-print-directory -C runtime-ext
 	@[ -d $@ ] || mkdir -p $@
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
+	make --no-print-directory -C runtime-ext clean
 	@rm -fr $(BUILD) $(OUTPUT).elf $(OUTPUT).dol patch.o
 #---------------------------------------------------------------------------------
 run:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In order to build this project, you need:
 - [DevkitPro](https://devkitpro.org/wiki/Getting_Started), specifically all packages in the `wii-dev` and `ppc-dev` groups.
 - Additional libraries: libcurl and brainslug (the `install-libs.sh` script can install them for you)
 
-This project uses a `Makefile` for building the project: running `make` in the root directory will build the project and produce a `RR-Launcher.dol` file.
+This project uses a `Makefile` for building the project: running `make` in the root directory will build the project and produce a `RR-Launcher.dol` file (the main DOL that starts the channel) as well as `runtime-ext/runtime-ext.dol` (used during the game which contains patched DVD functions to load RR code from the SD card).
 
 ### Contributing
 

--- a/runtime-ext/source/dvd.c
+++ b/runtime-ext/source/dvd.c
@@ -225,7 +225,12 @@ static bool rte_dvd_resolve_path_to_entry_num(const char *filename, s32 *entry_n
                 // The folder replacement path matches. Let's see if the file actually exists in the directory.
                 char new_path[64];
                 char *path_ptr = new_path;
-                strncpy(new_path, external_path, 64);
+                if (strlen(external_path) >= 64)
+                {
+                    RTE_FATAL("External path '%s' is too long", external_path);
+                }
+                strncpy(new_path, external_path, sizeof(new_path));
+
                 path_ptr += external_len;
                 if (filename[fi] != '/' && external_path[external_len - 1] != '/')
                 {

--- a/source/loader.c
+++ b/source/loader.c
@@ -600,18 +600,18 @@ void rrc_loader_load(struct rrc_dol *dol, struct rrc_settingsfile *settings, con
 
     // Addresses are taken from <https://wiibrew.org/wiki/Memory_map> for the most part.
 
-    *(u32 *)0xCD006C00 = 0x00000000;           // Reset `AI_CONTROL` to fix audio
-    *(u32 *)0x80000034 = 0;                    // Arena High
-    *(u32 *)0x800000EC = 0x81800000;           // Dev Debugger Monitor Address
-    *(u32 *)0x800000F0 = 0x01800000;           // Simulated Memory Size
-    *(u32 *)0x800000F4 = (u32)bi2_dest;        // Pointer to bi2
-    *(u32 *)0x800000F8 = 0x0E7BE2C0;           // Console Bus Speed
-    *(u32 *)0x800000FC = 0x2B73A840;           // Console CPU Speed
-    *(u32 *)0x80003110 = mem1_hi;              // MEM1 Arena End
-    *(u32 *)0x80003124 = 0x90000800;           // Usable MEM2 Start
-    *(u32 *)0x80003128 = mem2_hi;              // Usable MEM2 End
-    *(u32 *)0x80003180 = *(u32 *)(0x80000000); // Game ID
-    *(u32 *)0x80003188 = *(u32 *)(0x80003140); // Minimum IOS Version
+    *(u32 *)0xCD006C00 = 0x00000000;              // Reset `AI_CONTROL` to fix audio
+    *(u32 *)0x80000034 = 0;                       // Arena High
+    *(u32 *)0x800000EC = 0x81800000;              // Dev Debugger Monitor Address
+    *(u32 *)0x800000F0 = 0x01800000;              // Simulated Memory Size
+    *(u32 *)0x800000F4 = (u32)bi2_dest;           // Pointer to bi2
+    *(u32 *)0x800000F8 = 0x0E7BE2C0;              // Console Bus Speed
+    *(u32 *)0x800000FC = 0x2B73A840;              // Console CPU Speed
+    *(u32 *)0x80003110 = align_down(mem1_hi, 32); // MEM1 Arena End
+    *(u32 *)0x80003124 = 0x90000800;              // Usable MEM2 Start
+    *(u32 *)0x80003128 = align_down(mem2_hi, 32); // Usable MEM2 End
+    *(u32 *)0x80003180 = *(u32 *)(0x80000000);    // Game ID
+    *(u32 *)0x80003188 = *(u32 *)(0x80003140);    // Minimum IOS Version
 
     memcpy((u32 *)0x80000000, "RMCP01", 6);
     DCFlushRange((u32 *)0x80000000, 32);

--- a/source/loader.h
+++ b/source/loader.h
@@ -35,7 +35,7 @@
 #define RRC_DVD_CLOSE 0x8015e568
 
 #define RRC_LOADER_PUL_PATH "RetroRewind6/Binaries/Loader.pul"
-#define RRC_RUNTIME_EXT_REL_PATH "runtime-ext.dol"
+#define RRC_RUNTIME_EXT_PATH "RetroRewindChannel/runtime-ext.dol"
 
 /*
  * Spins until Mario Kart Wii is inserted into the disc drive.
@@ -55,6 +55,6 @@ int rrc_loader_locate_data_part(u32 *part);
  *
  * This function should always return a status code on failure and NEVER CRASH. On success, it never returns.
  */
-void rrc_loader_load(struct rrc_dol *dol, struct rrc_settingsfile *settings, const char *apps_cwd, void *bi2_dest, u32 mem1_hi, u32 mem2_hi);
+void rrc_loader_load(struct rrc_dol *dol, struct rrc_settingsfile *settings, void *bi2_dest, u32 mem1_hi, u32 mem2_hi);
 
 #endif

--- a/source/main.c
+++ b/source/main.c
@@ -76,8 +76,7 @@ int main(int argc, char **argv)
     init_exception_handlers();
 
     // NOTE: We can't call any kind of printf before initialising libfat
-    char apps_cwd[256];
-    struct rrc_result sdinit_res = rrc_sd_init(apps_cwd, sizeof(apps_cwd));
+    struct rrc_result sdinit_res = rrc_sd_init();
     rrc_result_error_check_error_fatal(&sdinit_res);
 
     rrc_con_update("Initialise controllers", 0);
@@ -284,7 +283,7 @@ interrupt_loop_end:
     {
         mem2_hi = 0x93400000;
     }
-    rrc_loader_load(dol, &stored_settings, apps_cwd, bi2, mem1_hi, mem2_hi);
+    rrc_loader_load(dol, &stored_settings, bi2, mem1_hi, mem2_hi);
 
     return 0;
 }

--- a/source/sd.c
+++ b/source/sd.c
@@ -22,7 +22,7 @@
 
 #include "sd.h"
 
-struct rrc_result rrc_sd_init(char *old_cwd, int buf_size)
+struct rrc_result rrc_sd_init()
 {
     if (!fatInitDefault())
     {
@@ -33,11 +33,6 @@ struct rrc_result rrc_sd_init(char *old_cwd, int buf_size)
                 .errnocode = EIO}};
 
         return sdfail;
-    }
-
-    if (!getcwd(old_cwd, buf_size))
-    {
-        return rrc_result_create_error_errno(errno, "Failed to get current working directory");
     }
 
     if (chdir("sd:/") == -1)

--- a/source/sd.h
+++ b/source/sd.h
@@ -31,6 +31,6 @@
     Otherwise, an error is returned. This error can either be treated as fatal or
     prompt the user to retry inserting with an unlocked SD card.
 */
-struct rrc_result rrc_sd_init(char *old_cwd, int buf_size);
+struct rrc_result rrc_sd_init();
 
 #endif

--- a/source/settingsfile.c
+++ b/source/settingsfile.c
@@ -43,7 +43,7 @@
 #include "settingsfile.h"
 #include "util.h"
 
-#define RRC_SETTINGSFILE_PATH "RetroRewind6/.settings"
+#define RRC_SETTINGSFILE_PATH "RetroRewindChannel/.settings"
 #define RRC_SETTINGSFILE_MY_STUFF_KEY "My Stuff"
 #define RRC_SETTINGSFILE_LANGUAGE_KEY "Language"
 #define RRC_SETTINGSFILE_SAVEGAME_KEY "Separate savegame"


### PR DESCRIPTION
- Fixes #52
- Fixes #51 
- Addresses the first point of #46 (runtime-ext is now built as part of the main makefile)
- Briefly mention the second DOL in the Readme
- Fixes some warnings