### PR TITLE
Properly close zip files

### DIFF
--- a/source/update/update.c
+++ b/source/update/update.c
@@ -359,6 +359,7 @@ struct rrc_result rrc_update_extract_zip_archive()
         }
 
         fclose(outfile);
+        zip_fclose(zip_file);
     }
 
     zip_close(archive);


### PR DESCRIPTION
Fixes #50

Tested this by downloading all updates since 4.0.0, launching works without any errors now