### PR TITLE
Support reset and power button handling

### DIFF
--- a/source/exception.c
+++ b/source/exception.c
@@ -34,6 +34,7 @@
 #include <gccore.h>
 #include <ogc/wiilaunch.h>
 
+#include "shutdown.h"
 #include "exception.h"
 #include "console.h"
 #include "gui.h"
@@ -108,7 +109,11 @@ void _handle_exception(int exception)
         x++;
     }
 
-    usleep(EXCEPTION_DISPLAY_TIME_SEC * 1000 * 1000);
+    for (int i = 0; i < EXCEPTION_DISPLAY_TIME_SEC * 1000; i++)
+    {
+        rrc_shutdown_check();
+        usleep(1000);
+    }
 
     for (;;)
         _exit(-1);
@@ -134,7 +139,7 @@ void init_exception_handlers()
 
     for (vector = 0x100; vector < 0x800; vector += 0x10)
     {
-        /* ingore IRQs */
+        /* ignore IRQs */
         if (vector < 0x500 || vector >= 0x600)
         {
             u32 *instr = (u32 *)(0x80000000 + vector);

--- a/source/main.c
+++ b/source/main.c
@@ -30,6 +30,7 @@
 #include <sys/statvfs.h>
 #include <errno.h>
 
+#include "shutdown.h"
 #include "util.h"
 #include "di.h"
 #include "time.h"
@@ -57,6 +58,8 @@ int main(int argc, char **argv)
     // Use a version used by the game that is known to work with pulsar.
     // FIXME: try to use the disk's IOS version?
     RRC_ASSERTEQ(IOS_ReloadIOS(37), 0, "Failed to reload IOS");
+
+    rrc_shutdown_register_callbacks();
 
     // We reserve ~1MB of MEM1 upfront for the runtime-ext dol.
     u32 mem1_hi = 0x81744260;
@@ -178,6 +181,8 @@ int main(int argc, char **argv)
 
     for (int i = 0; i < INTERRUPT_TIME / RRC_WPAD_LOOP_TIMEOUT; i++)
     {
+        rrc_shutdown_check();
+
         PAD_ScanPads();
         WPAD_ScanPads();
 

--- a/source/prompt.c
+++ b/source/prompt.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <ogc/wiilaunch.h>
 
+#include "shutdown.h"
 #include "console.h"
 #include "prompt.h"
 #include "util.h"
@@ -119,6 +120,7 @@ enum rrc_prompt_result rrc_prompt_2_options(
 
     while (1)
     {
+        rrc_shutdown_check();
         PAD_ScanPads();
         WPAD_ScanPads();
         int wiipressed = WPAD_ButtonsDown(0);
@@ -215,6 +217,7 @@ void rrc_prompt_1_option(void *old_xfb,
     // just wait for an A press lol
     while (1)
     {
+        rrc_shutdown_check();
         WPAD_ScanPads();
         PAD_ScanPads();
         int wiipressed = WPAD_ButtonsDown(0);

--- a/source/result.c
+++ b/source/result.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 #include <gccore.h>
 
+#include "shutdown.h"
 #include "prompt.h"
 #include "result.h"
 
@@ -193,6 +194,11 @@ void rrc_result_error_check_error_fatal(struct rrc_result *result)
     printf(RRC_CON_ANSI_FG_BRIGHT_CYAN "Additional info: " RRC_CON_ANSI_FG_WHITE "%s\n", result->context);
     printf("\n\nPlease check your installation of Retro Rewind.\nThe launcher will exit in %i seconds.", RRC_RESULT_FATAL_SPLASH_TIME_SEC);
 
-    usleep(RRC_RESULT_FATAL_SPLASH_TIME_SEC * 1000 * 1000);
+    for (int i = 0; i < RRC_RESULT_FATAL_SPLASH_TIME_SEC * 1000; i++)
+    {
+        rrc_shutdown_check();
+        usleep(1000);
+    }
+
     exit(1);
 }

--- a/source/settings.c
+++ b/source/settings.c
@@ -17,6 +17,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include "shutdown.h"
 #include "settings.h"
 #include "util.h"
 #include "console.h"
@@ -280,6 +281,7 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
 
     while (1)
     {
+        rrc_shutdown_check();
         int row = RRC_SETTINGS_ROW_START;
         bool has_unsaved_changes = false;
 

--- a/source/shutdown.c
+++ b/source/shutdown.c
@@ -1,0 +1,64 @@
+/*
+    shutdown.h - Shutdown and reset handler checker
+    Copyright (C) 2025  Retro Rewind Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <gccore.h>
+
+#include "console.h"
+#include "time.h"
+
+#define RRC_SHUTDOWN_CHECK_TIME_MS 2500
+
+static volatile int _shutdown_state = -1;
+/* Only actually trigger the shutdown if we check for it within RRC_SHUTDOWN_CHECK_TIME_MS -
+   This is handy in the event we get this during an update and may not check until a minute
+   or two later */
+static rrc_time_tick _shutdown_time = 0;
+
+void power_callback()
+{
+    _shutdown_time = gettime();
+    _shutdown_state = SYS_POWEROFF;
+}
+
+void reset_callback(u32 irq, void *ctx)
+{
+    _shutdown_time = gettime();
+    _shutdown_state = SYS_RETURNTOMENU;
+}
+
+void rrc_shutdown_register_callbacks()
+{
+    SYS_SetPowerCallback(power_callback);
+    SYS_SetResetCallback(reset_callback);
+}
+
+void rrc_shutdown_check()
+{
+    int time_since_trigger = diff_msec(_shutdown_time, gettime());
+
+    if (_shutdown_state != -1 && time_since_trigger < RRC_SHUTDOWN_CHECK_TIME_MS)
+    {
+        rrc_con_update("Shutting Down", 100);
+        SYS_ResetSystem(_shutdown_state, 0, 0);
+    }
+    /* set state back to off if not triggered in time */
+    else if (time_since_trigger >= RRC_SHUTDOWN_CHECK_TIME_MS)
+    {
+        _shutdown_state = -1;
+    }
+}

--- a/source/shutdown.h
+++ b/source/shutdown.h
@@ -1,0 +1,26 @@
+/*
+    shutdown.h - Shutdown and reset handler check header
+    Copyright (C) 2025  Retro Rewind Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef RRC_SHUTDOWN_H
+#define RRC_SHUTDOWN_H
+
+void rrc_shutdown_register_callbacks();
+
+void rrc_shutdown_check();
+
+#endif

--- a/source/update/update.c
+++ b/source/update/update.c
@@ -33,6 +33,7 @@
 #include "../console.h"
 #include "../time.h"
 #include "../prompt.h"
+#include "../shutdown.h"
 
 #define _RRC_UPDATE_ZIP_NAME "update.zip"
 
@@ -403,6 +404,9 @@ struct rrc_result rrc_update_do_updates_with_state(struct rrc_update_state *stat
 {
     while (state->current_update_num < state->num_updates)
     {
+        /* We can check for this between updates since we have no in-flight information */
+        rrc_shutdown_check();
+
         char *url = state->update_urls[state->current_update_num];
 
         curl_off_t zipsz;


### PR DESCRIPTION
Closes #55 

Adds a small API that registers callbacks for power and reset triggers. All code that waits on user input or otherwise has a significant delay should call `rrc_shutdown_check()` on each iteration of the loop.

We deliberately don't check for this during an update since that could corrupt an install; however, pushing the power button would trigger a shutdown on the next check which could be minutes later. To mitigate this, a timeout has been added in which the request must be handled before it is ignored.