### PR TITLE
Remove languages from the channel

### DIFF
--- a/source/loader/riivo_patch_loader.c
+++ b/source/loader/riivo_patch_loader.c
@@ -143,7 +143,6 @@ struct rrc_result rrc_riivo_patch_loader_parse(struct rrc_settingsfile *settings
     mxml_index_t *options_index = mxmlIndexNew(xml_top, "option", NULL);
 
     rrc_patch_loader_append_patches_for_option(xml_top, options_index, "My Stuff", settings->my_stuff, active_patches, &active_patches_count);
-    rrc_patch_loader_append_patches_for_option(xml_top, options_index, "Language", settings->language, active_patches, &active_patches_count);
     // Just always enable the pack, there is no setting for this.
     rrc_patch_loader_append_patches_for_option(xml_top, options_index, "Pack", RRC_SETTINGSFILE_PACK_ENABLED_VALUE, active_patches, &active_patches_count);
 

--- a/source/settings.c
+++ b/source/settings.c
@@ -76,7 +76,6 @@ static char *changes_saved_status = RRC_CON_ANSI_FG_GREEN "Changes saved." RRC_C
 static char *changes_not_saved_status = RRC_CON_ANSI_BG_BRIGHT_RED "Error saving changes." RRC_CON_ANSI_CLR;
 
 static char *my_stuff_label = "My Stuff";
-static char *language_label = "Language";
 static char *savegame_label = "Separate savegame";
 static char *autoupdate_label = "Automatic updates";
 
@@ -152,7 +151,6 @@ static bool prompt_save_unsaved_changes(void *xfb, const struct settings_entry *
 
 #define CLEANUP             \
     free(my_stuff_options); \
-    free(language_options); \
     free(savegame_options); \
     mxmlDelete(xml_top);    \
     fclose(xml_file);
@@ -174,22 +172,13 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
     mxml_node_t *xml_options = mxmlFindElement(xml_top, xml_top, "options", NULL, NULL, MXML_DESCEND);
     RRC_ASSERT(xml_options != NULL, "no <options> tag in xml");
 
-    const char **my_stuff_options, **language_options, **savegame_options;
-    int my_stuff_options_count, language_options_count, savegame_options_count;
+    const char **my_stuff_options, **savegame_options;
+    int my_stuff_options_count, savegame_options_count;
     const char *autoupdate_options[] = {"Disabled", "Enabled"};
     int autoupdate_option_count = sizeof(autoupdate_options) / sizeof(char *);
 
     struct rrc_result r;
     r = xml_find_option_choices(xml_options, xml_top, "My Stuff", &my_stuff_options, &my_stuff_options_count, &stored_settings->my_stuff);
-    if (rrc_result_is_error(&r))
-    {
-        result->context = r.context;
-        result->errtype = r.errtype;
-        result->inner = r.inner;
-        return RRC_SETTINGS_ERROR;
-    }
-
-    r = xml_find_option_choices(xml_options, xml_top, "Language", &language_options, &language_options_count, &stored_settings->language);
     if (rrc_result_is_error(&r))
     {
         result->context = r.context;
@@ -222,12 +211,6 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
          .initial_selected_option = stored_settings->my_stuff,
          .option_count = my_stuff_options_count,
          .margin_top = 1},
-        {.type = ENTRY_TYPE_SELECT,
-         .label = language_label,
-         .options = language_options,
-         .selected_option = &stored_settings->language,
-         .initial_selected_option = stored_settings->language,
-         .option_count = language_options_count},
         {.type = ENTRY_TYPE_SELECT,
          .label = savegame_label,
          .options = savegame_options,
@@ -456,7 +439,7 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
                     }
 
                     strncpy(status_message, changes_saved_status, sizeof(status_message));
-                    status_message_row = 12;
+                    status_message_row = 11;
                     status_message_col = strlen(cursor_icon) + strlen(save_label) + 3;
 
                     break;

--- a/source/settingsfile.c
+++ b/source/settingsfile.c
@@ -46,7 +46,6 @@
 
 #define RRC_SETTINGSFILE_PATH "RetroRewindChannel/.settings"
 #define RRC_SETTINGSFILE_MY_STUFF_KEY "My Stuff"
-#define RRC_SETTINGSFILE_LANGUAGE_KEY "Language"
 #define RRC_SETTINGSFILE_SAVEGAME_KEY "Separate savegame"
 #define RRC_SETTINGSFILE_AUTOUPDATE_KEY "Auto update"
 #define RRC_SETTINGSFILE_MAGIC 1920234103
@@ -104,7 +103,6 @@ struct rrc_result rrc_settingsfile_create()
 void rrc_settingsfile_init_defaults(struct rrc_settingsfile *settings)
 {
     settings->my_stuff = RRC_SETTINGSFILE_DEFAULT;
-    settings->language = RRC_SETTINGSFILE_DEFAULT;
     settings->savegame = RRC_SETTINGSFILE_DEFAULT;
     settings->auto_update = RRC_SETTINGSFILE_AUTOUPDATE_DEFAULT;
 }
@@ -183,10 +181,6 @@ struct rrc_result rrc_settingsfile_parse(struct rrc_settingsfile *settings)
         {
             settings->my_stuff = value;
         }
-        else if (strcmp(key, RRC_SETTINGSFILE_LANGUAGE_KEY) == 0)
-        {
-            settings->language = value;
-        }
         else if (strcmp(key, RRC_SETTINGSFILE_SAVEGAME_KEY) == 0)
         {
             settings->savegame = value;
@@ -239,10 +233,9 @@ struct rrc_result rrc_settingsfile_store(struct rrc_settingsfile *settings)
         return rrc_result_create_error_errno(errno, "Failed to open settingsfile");
     }
 
-    rrc_settingsfile_write_header(file, 4);
+    rrc_settingsfile_write_header(file, 3);
 
     TRY(rrc_settingsfile_set_option(file, RRC_SETTINGSFILE_MY_STUFF_KEY, settings->my_stuff));
-    TRY(rrc_settingsfile_set_option(file, RRC_SETTINGSFILE_LANGUAGE_KEY, settings->language));
     TRY(rrc_settingsfile_set_option(file, RRC_SETTINGSFILE_SAVEGAME_KEY, settings->savegame));
     TRY(rrc_settingsfile_set_option(file, RRC_SETTINGSFILE_AUTOUPDATE_KEY, settings->auto_update));
 

--- a/source/settingsfile.h
+++ b/source/settingsfile.h
@@ -38,7 +38,6 @@ enum rrc_settingsfile_status
 struct rrc_settingsfile
 {
     u32 my_stuff;
-    u32 language;
     u32 savegame;
     u32 auto_update;
 };


### PR DESCRIPTION
A change in the last update broke the xml parsing. Language options are no longer part of the xml, so just remove it from the channel entirely.