### PR TITLE
Fix uaf in error creation

### DIFF
--- a/source/loader/binary_loader.c
+++ b/source/loader/binary_loader.c
@@ -70,7 +70,7 @@ static void get_runtime_ext_path(char region, char *out)
     snprintf(out, 64, RRC_RUNTIME_EXT_BASE_PATH "-%c.dol", region);
 }
 
-struct rrc_result rrc_binary_load_runtime_ext(char region)
+void rrc_binary_load_runtime_ext(char region)
 {
     char runtime_ext_path[64];
     get_runtime_ext_path(region, runtime_ext_path);
@@ -80,7 +80,8 @@ struct rrc_result rrc_binary_load_runtime_ext(char region)
     {
         char err[64];
         snprintf(err, sizeof(err), "Failed to open %s", runtime_ext_path);
-        return rrc_result_create_error_errno(errno, err);
+        struct rrc_result res = rrc_result_create_error_errno(errno, err);
+        rrc_result_error_check_error_fatal(&res);
     }
     struct rrc_dol patch_dol;
 
@@ -90,7 +91,8 @@ struct rrc_result rrc_binary_load_runtime_ext(char region)
         fclose(patch_file);
         char err[64];
         snprintf(err, sizeof(err), "Failed to read %s", runtime_ext_path);
-        return rrc_result_create_error_errno(errno, err);
+        struct rrc_result res = rrc_result_create_error_errno(errno, err);
+        rrc_result_error_check_error_fatal(&res);
     }
 
     memset((void *)patch_dol.bss_addr, 0, patch_dol.bss_size);
@@ -114,7 +116,8 @@ struct rrc_result rrc_binary_load_runtime_ext(char region)
             fclose(patch_file);
             char err[64];
             snprintf(err, sizeof(err), "Failed to seek to section %i in %s", sec, runtime_ext_path);
-            return rrc_result_create_error_errno(errno, err);
+            struct rrc_result res = rrc_result_create_error_errno(errno, err);
+            rrc_result_error_check_error_fatal(&res);
         }
 
         if (fread((void *)sec_addr, sec_size, 1, patch_file) != 1)
@@ -122,12 +125,12 @@ struct rrc_result rrc_binary_load_runtime_ext(char region)
             fclose(patch_file);
             char err[64];
             snprintf(err, sizeof(err), "Failed to read section %i in %s", sec, runtime_ext_path);
-            return rrc_result_create_error_errno(errno, err);
+            struct rrc_result res = rrc_result_create_error_errno(errno, err);
+            rrc_result_error_check_error_fatal(&res);
         }
 
         rrc_invalidate_cache((void *)sec_addr, sec_size);
     }
 
     fclose(patch_file);
-    return rrc_result_success;
 }

--- a/source/loader/binary_loader.h
+++ b/source/loader/binary_loader.h
@@ -41,6 +41,6 @@ bool rrc_binary_find_section_by_addr(struct rrc_dol *dol, u32 addr, void **virt_
 
 struct rrc_result rrc_binary_load_pulsar_loader(struct rrc_dol *dol, void *real_loader_addr);
 
-struct rrc_result rrc_binary_load_runtime_ext(char region);
+void rrc_binary_load_runtime_ext(char region);
 
 #endif

--- a/source/loader/loader.c
+++ b/source/loader/loader.c
@@ -147,8 +147,7 @@ void rrc_loader_load(struct rrc_dol *dol, struct rrc_settingsfile *settings, voi
     // runtime-ext needs to be loaded before parsing riivo patches, as it writes to a static.
     // All errors that happen here are fatal; we can't boot the game without knowing the patches or having the patched DVD functions.
     rrc_con_update("Load Runtime Extensions", 70);
-    res = rrc_binary_load_runtime_ext(region);
-    rrc_result_error_check_error_fatal(&res);
+    rrc_binary_load_runtime_ext(region);
 
     rrc_con_update("Load Patch Information", 80);
     struct parse_riivo_output riivo_out;


### PR DESCRIPTION
This was causing empty/corrupted error messages.

These error cases were returning an error containing a pointer to a stack array that gets destroyed upon returning. Since this function just has a single caller that immediately fatally reports it anyway, just report that in the function itself.

(The alternative would be just passing static strings to the errors, but some of the dynamic info does seem useful so I opted for keeping it like that)