### PR TITLE
Support dynamic string context in errors

### DIFF
--- a/source/console.c
+++ b/source/console.c
@@ -91,7 +91,7 @@ void rrc_con_display_version()
     if (cached_version == -1)
     {
         struct rrc_result version_result = rrc_update_get_current_version(&cached_version);
-        rrc_result_error_check_error_fatal(&version_result);
+        rrc_result_error_check_error_fatal(version_result);
     }
 
     char vertext[32];

--- a/source/loader/binary_loader.c
+++ b/source/loader/binary_loader.c
@@ -81,7 +81,7 @@ void rrc_binary_load_runtime_ext(char region)
         char err[64];
         snprintf(err, sizeof(err), "Failed to open %s", runtime_ext_path);
         struct rrc_result res = rrc_result_create_error_errno(errno, err);
-        rrc_result_error_check_error_fatal(&res);
+        rrc_result_error_check_error_fatal(res);
     }
     struct rrc_dol patch_dol;
 
@@ -92,7 +92,7 @@ void rrc_binary_load_runtime_ext(char region)
         char err[64];
         snprintf(err, sizeof(err), "Failed to read %s", runtime_ext_path);
         struct rrc_result res = rrc_result_create_error_errno(errno, err);
-        rrc_result_error_check_error_fatal(&res);
+        rrc_result_error_check_error_fatal(res);
     }
 
     memset((void *)patch_dol.bss_addr, 0, patch_dol.bss_size);
@@ -117,7 +117,7 @@ void rrc_binary_load_runtime_ext(char region)
             char err[64];
             snprintf(err, sizeof(err), "Failed to seek to section %i in %s", sec, runtime_ext_path);
             struct rrc_result res = rrc_result_create_error_errno(errno, err);
-            rrc_result_error_check_error_fatal(&res);
+            rrc_result_error_check_error_fatal(res);
         }
 
         if (fread((void *)sec_addr, sec_size, 1, patch_file) != 1)
@@ -126,7 +126,7 @@ void rrc_binary_load_runtime_ext(char region)
             char err[64];
             snprintf(err, sizeof(err), "Failed to read section %i in %s", sec, runtime_ext_path);
             struct rrc_result res = rrc_result_create_error_errno(errno, err);
-            rrc_result_error_check_error_fatal(&res);
+            rrc_result_error_check_error_fatal(res);
         }
 
         rrc_invalidate_cache((void *)sec_addr, sec_size);

--- a/source/loader/loader.c
+++ b/source/loader/loader.c
@@ -63,7 +63,7 @@ static void patch_dvd_functions(struct rrc_dol *dol, char region)
         char e[64];
         snprintf(e, sizeof(e), "Unsupported region %c", region);
         struct rrc_result res = rrc_result_create_error_errno(ENOTSUP, e);
-        rrc_result_error_check_error_fatal(&res);
+        rrc_result_error_check_error_fatal(res);
     }
 
     // We need to hack around the fact you can't assign to arrays unless the rhs is a constant
@@ -152,12 +152,12 @@ void rrc_loader_load(struct rrc_dol *dol, struct rrc_settingsfile *settings, voi
     rrc_con_update("Load Patch Information", 80);
     struct parse_riivo_output riivo_out;
     res = rrc_riivo_patch_loader_parse(settings, &mem1_hi, &mem2_hi, &riivo_out);
-    rrc_result_error_check_error_fatal(&res);
+    rrc_result_error_check_error_fatal(res);
 
     rrc_con_update("Patch DVD Functions", 85);
     patch_dvd_functions(dol, region);
     res = rrc_binary_load_pulsar_loader(dol, riivo_out.loader_pul_dest);
-    rrc_result_error_check_error_fatal(&res);
+    rrc_result_error_check_error_fatal(res);
 
     rrc_gui_video_fix(region);
 

--- a/source/loader/riivo_patch_loader.c
+++ b/source/loader/riivo_patch_loader.c
@@ -142,9 +142,9 @@ struct rrc_result rrc_riivo_patch_loader_parse(struct rrc_settingsfile *settings
 
     mxml_index_t *options_index = mxmlIndexNew(xml_top, "option", NULL);
 
-    rrc_patch_loader_append_patches_for_option(xml_top, options_index, "My Stuff", settings->my_stuff, active_patches, &active_patches_count);
+    TRY(rrc_patch_loader_append_patches_for_option(xml_top, options_index, "My Stuff", settings->my_stuff, active_patches, &active_patches_count));
     // Just always enable the pack, there is no setting for this.
-    rrc_patch_loader_append_patches_for_option(xml_top, options_index, "Pack", RRC_SETTINGSFILE_PACK_ENABLED_VALUE, active_patches, &active_patches_count);
+    TRY(rrc_patch_loader_append_patches_for_option(xml_top, options_index, "Pack", RRC_SETTINGSFILE_PACK_ENABLED_VALUE, active_patches, &active_patches_count));
 
     // FIXME: Handle savegame options.
 

--- a/source/main.c
+++ b/source/main.c
@@ -83,22 +83,24 @@ int main(int argc, char **argv)
 
     // NOTE: We can't call any kind of printf before initialising libfat
     struct rrc_result sdinit_res = rrc_sd_init();
-    rrc_result_error_check_error_fatal(&sdinit_res);
+    rrc_result_error_check_error_fatal(sdinit_res);
 
     errno = 0;
-    
-    DIR* dir = opendir("sd:/RetroRewindChannel");
-    if(dir != NULL)
+
+    DIR *dir = opendir("sd:/RetroRewindChannel");
+    if (dir != NULL)
     {
         closedir(dir);
-    } else if(errno == ENOENT)
+    }
+    else if (errno == ENOENT)
     {
         mkdir("sd:/RetroRewindChannel", 0);
-    } else
+    }
+    else
     {
         // ???
-       struct rrc_result err = rrc_result_create_error_errno(errno, "Failed to open sd:/RetroRewindChannel");
-       rrc_result_error_check_error_fatal(&err);
+        struct rrc_result err = rrc_result_create_error_errno(errno, "Failed to open sd:/RetroRewindChannel");
+        rrc_result_error_check_error_fatal(err);
     }
 
     rrc_con_update("Initialise controllers", 0);
@@ -131,7 +133,7 @@ int main(int argc, char **argv)
         if (afd == NULL)
         {
             struct rrc_result err = rrc_result_create_error_errno(errno, "Failed to create acceptance file. The SD card may be locked.");
-            rrc_result_error_check_error_normal(&err, xfb);
+            rrc_result_error_check_error_normal(err, xfb);
         }
         else
         {
@@ -190,29 +192,32 @@ int main(int argc, char **argv)
     rrc_con_update("Load settings", 20);
     struct rrc_settingsfile stored_settings;
     struct rrc_result settingsfile_res = rrc_settingsfile_parse(&stored_settings);
-    if (rrc_result_is_error(&settingsfile_res))
+    if (rrc_result_is_error(settingsfile_res))
     {
         char *lines[] = {
-            rrc_result_strerror(&settingsfile_res),
-            (char *)settingsfile_res.context,
+            rrc_result_strerror(settingsfile_res),
+            (char *)rrc_result_context(settingsfile_res),
             "It may be possible to fix this by recreating the file.",
             "Recreate now?",
         };
+        rrc_result_free(settingsfile_res);
+
         enum rrc_prompt_result prompt_res = rrc_prompt_yes_no(xfb, lines, 4);
 
         if (prompt_res == RRC_PROMPT_RESULT_YES)
         {
             settingsfile_res = rrc_settingsfile_create();
-            if (rrc_result_is_error(&settingsfile_res))
+            if (rrc_result_is_error(settingsfile_res))
             {
                 char *lines[] = {
                     "Failed to recreate settings file.",
-                    rrc_result_strerror(&settingsfile_res),
-                    (char *)settingsfile_res.context,
+                    rrc_result_strerror(settingsfile_res),
+                    (char *)rrc_result_context(settingsfile_res),
                     "Defaults will be used with no changes on the SD card.",
                 };
                 rrc_prompt_1_option(xfb, lines, 4, "OK");
             }
+            rrc_result_free(settingsfile_res);
         }
 
         // `rrc_settingsfile_parse()` always initializes the settingsfile, so even in case of an error here,
@@ -226,7 +231,7 @@ int main(int argc, char **argv)
         int update_count;
         bool any_updates;
         struct rrc_result update_res = rrc_update_do_updates(xfb, &update_count, &any_updates);
-        rrc_result_error_check_error_normal(&update_res, xfb);
+        rrc_result_error_check_error_normal(update_res, xfb);
     }
 
 #define INTERRUPT_TIME 3000000 /* 3 seconds */
@@ -253,7 +258,7 @@ int main(int argc, char **argv)
         {
             struct rrc_result r;
             int out = rrc_settings_display(xfb, &stored_settings, &r);
-            rrc_result_error_check_error_fatal(&r);
+            rrc_result_error_check_error_fatal(r);
 
             switch (out)
             {

--- a/source/sd.c
+++ b/source/sd.c
@@ -26,13 +26,7 @@ struct rrc_result rrc_sd_init()
 {
     if (!fatInitDefault())
     {
-        struct rrc_result sdfail = {
-            .errtype = ESOURCE_SD_CARD,
-            .context = "Couldn't mount the SD card - is it inserted?",
-            .inner = {
-                .errnocode = EIO}};
-
-        return sdfail;
+        return rrc_result_create_error_sdcard(EIO, "Couldn't mount the SD card - is it inserted?");
     }
 
     if (chdir("sd:/") == -1)

--- a/source/settings.c
+++ b/source/settings.c
@@ -157,14 +157,13 @@ static bool prompt_save_unsaved_changes(void *xfb, const struct settings_entry *
 
 enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile *stored_settings, struct rrc_result *result)
 {
-    result->errtype = ESOURCE_NONE;
+    *result = rrc_result_success;
 
     // Read the XML to extract all possible options for the entries.
     FILE *xml_file = fopen(RRC_RIIVO_XML_PATH, "r");
     if (!xml_file)
     {
-        struct rrc_result r = rrc_result_create_error_errno(errno, "Failed to open " RRC_RIIVO_XML_PATH);
-        memcpy(result, &r, sizeof(struct rrc_result));
+        *result = rrc_result_create_error_errno(errno, "Failed to open " RRC_RIIVO_XML_PATH);
         return RRC_SETTINGS_ERROR;
     }
     mxml_node_t *xml_top = mxmlLoadFile(NULL, xml_file, NULL);
@@ -179,20 +178,16 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
 
     struct rrc_result r;
     r = xml_find_option_choices(xml_options, xml_top, "My Stuff", &my_stuff_options, &my_stuff_options_count, &stored_settings->my_stuff);
-    if (rrc_result_is_error(&r))
+    if (rrc_result_is_error(r))
     {
-        result->context = r.context;
-        result->errtype = r.errtype;
-        result->inner = r.inner;
+        *result = r;
         return RRC_SETTINGS_ERROR;
     }
 
     r = xml_find_option_choices(xml_options, xml_top, "Seperate Savegame", &savegame_options, &savegame_options_count, &stored_settings->separate_savegame);
-    if (rrc_result_is_error(&r))
+    if (rrc_result_is_error(r))
     {
-        result->context = r.context;
-        result->errtype = r.errtype;
-        result->inner = r.inner;
+        *result = r;
         return RRC_SETTINGS_ERROR;
     }
 
@@ -414,7 +409,7 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
                     if (has_unsaved_changes && prompt_save_unsaved_changes(xfb, entries, entry_count))
                     {
                         struct rrc_result res = rrc_settingsfile_store(stored_settings);
-                        rrc_result_error_check_error_normal(&res, xfb);
+                        rrc_result_error_check_error_normal(res, xfb);
                     }
 
                     goto launch;
@@ -422,13 +417,13 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
                 else if (entry->label == save_label)
                 {
                     struct rrc_result res = rrc_settingsfile_store(stored_settings);
-                    rrc_result_error_check_error_normal(&res, xfb);
-
-                    if (rrc_result_is_error(&res))
+                    if (rrc_result_is_error(res))
                     {
                         strncpy(status_message, changes_not_saved_status, sizeof(status_message));
                         break;
                     }
+
+                    rrc_result_error_check_error_normal(res, xfb);
 
                     for (int i = 0; i < entry_count; i++)
                     {
@@ -450,9 +445,9 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
                     bool updated;
                     struct rrc_result update_res = rrc_update_do_updates(xfb, &update_count, &updated);
 
-                    if (rrc_result_is_error(&update_res))
+                    if (rrc_result_is_error(update_res))
                     {
-                        rrc_result_error_check_error_normal(&update_res, xfb);
+                        rrc_result_error_check_error_normal(update_res, xfb);
                     }
                     else
                     {
@@ -493,7 +488,7 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
                     if (has_unsaved_changes && prompt_save_unsaved_changes(xfb, entries, entry_count))
                     {
                         struct rrc_result res = rrc_settingsfile_store(stored_settings);
-                        rrc_result_error_check_error_normal(&res, xfb);
+                        rrc_result_error_check_error_normal(res, xfb);
                     }
 
                     goto exit;

--- a/source/update/update.c
+++ b/source/update/update.c
@@ -476,12 +476,7 @@ struct rrc_result rrc_update_do_updates(void *xfb, int *count, bool *updates_ins
     int res = wiisocket_init();
     if (res < 0)
     {
-        struct rrc_result r = {
-            .context = "Failed to connect to the internet. Please check your connection and internet settings.",
-            .errtype = ESOURCE_UPDATE_MISC,
-            .inner = {.wiisocket_init_code = res}};
-
-        return r;
+        return rrc_result_create_error_misc_update("Failed to connect to the internet. Please check your connection and internet settings.");
     }
 
     *updates_installed = false;

--- a/source/update/versionsfile.c
+++ b/source/update/versionsfile.c
@@ -316,7 +316,7 @@ struct rrc_result rrc_versionsfile_get_necessary_urls_and_versions(char *version
         int verint;
         struct rrc_result verstring_res = rrc_versionsfile_parse_verstring(parts[0], &verint);
 
-        if (rrc_result_is_error(&verstring_res))
+        if (rrc_result_is_error(verstring_res))
         {
             rrc_versionsfile_free_split(lines, count);
             return verstring_res;
@@ -379,7 +379,7 @@ struct rrc_result rrc_versionsfile_parse_deleted_files(char *input, int current_
         int verint;
         struct rrc_result verstring_res = rrc_versionsfile_parse_verstring(parts[0], &verint);
 
-        if (rrc_result_is_error(&verstring_res))
+        if (rrc_result_is_error(verstring_res))
         {
             rrc_versionsfile_free_split(lines, count);
             return verstring_res;


### PR DESCRIPTION
Before this change, the error context always had to be a "static string", which was limiting because you couldn't put some useful dynamic info into it even if you had some to display (like paths).

This PR changes the representation a bit to allow for it. The outside API stays mostly the same, except results are no longer passed by pointer, because now it is itself effectively a pointer. This also doesn't actually make use of it anywhere yet (will be useful elsewhere).

Since the error struct is now heap allocated, it needs to be manually freed. However this almost never needs to be done explicitly, because results almost always (except for 2 cases where its checked manually) eventually passed to the `check_*` functions, which can consume and free the result. (`check_error_fatal` actually doesn't because it just exits the process).