### PR TITLE
Don't install brainslug and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The channel is designed to be simple, but its code does contain some novel featu
 
 In order to build this project, you need:
 
-- [DevkitPro](https://devkitpro.org/wiki/Getting_Started), specifically all packages in the `wii-dev`, `ppc-dev` and `ppc-portlibs` groups.
+- [DevkitPro](https://devkitpro.org/wiki/Getting_Started), specifically all packages in the `wii-dev`, `ppc-dev` and `ppc-mxml` groups.
 - Additional libraries: libcurl (the `install-libs.sh` script can install them for you)
 
 This project uses a `Makefile` for building the project: running `make` in the root directory will build the project and produce a `RR-Launcher.dol` file (the main DOL that starts the channel),

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The channel aims to provide three main features:
 - Functionality to update Retro Rewind, and (optionally) automatically check for updates.
 - Provide basic configuration including language and "My Stuff" (for custom assets).
 
-The channel makes use of a simple text-based interface enclosed in a decorative banner. 
+The channel makes use of a simple text-based interface enclosed in a decorative banner.
 This is a stylistic choice intended to keep the dependency stack lightweight and the launcher itself performant.
 This style is heavily influenced by existing similar designs such as [YAWM ModWii Edition](https://github.com/modmii/YAWM-ModMii-Edition).
 
@@ -35,11 +35,11 @@ The channel is designed to be simple, but its code does contain some novel featu
 
 In order to build this project, you need:
 
-- [DevkitPro](https://devkitpro.org/wiki/Getting_Started), specifically all packages in the `wii-dev` and `ppc-dev` groups.
-- Additional libraries: libcurl and brainslug (the `install-libs.sh` script can install them for you)
+- [DevkitPro](https://devkitpro.org/wiki/Getting_Started), specifically all packages in the `wii-dev`, `ppc-dev` and `ppc-portlibs` groups.
+- Additional libraries: libcurl (the `install-libs.sh` script can install them for you)
 
 This project uses a `Makefile` for building the project: running `make` in the root directory will build the project and produce a `RR-Launcher.dol` file (the main DOL that starts the channel),
-as well as `runtime-ext/runtime-ext-*.dol` files, where * is all supported region codes. This file is loaded before the game and contains patched DVD functions to load RR code from the SD card.
+as well as `runtime-ext/runtime-ext-*.dol` files, where \* is all supported region codes. This file is loaded before the game and contains patched DVD functions to load RR code from the SD card.
 
 ### Contributing
 

--- a/install-libs.sh
+++ b/install-libs.sh
@@ -4,8 +4,10 @@ WIICURL='https://github.com/AndrewPiroli/wii-curl/releases/download/c8.12.1%2Bm3
 WIISOCKET='https://github.com/AndrewPiroli/wii-curl/releases/download/c8.12.1%2Bm3.6.2/libwiisocket-0.1-1-any.pkg.tar.gz'
 WIIMBEDTLS='https://github.com/AndrewPiroli/wii-curl/releases/download/c8.12.1%2Bm3.6.2/wii-mbedtls-3.6.2-2-any.pkg.tar.gz'
 
-mkdir /tmp/libs-temp-install
-cd /tmp/libs-temp-install
+# make a temp directory for the libs and delete it on exit
+INSTALL_DIR="$(mktemp -d)"
+trap "rm -r $INSTALL_DIR" EXIT
+cd $INSTALL_DIR
 
 wget $WIICURL
 wget $WIISOCKET
@@ -15,11 +17,5 @@ tar -xvf wii-curl-8.12.1-1-any.pkg.tar.gz
 tar -xvf wii-mbedtls-3.6.2-2-any.pkg.tar.gz
 tar -xvf libwiisocket-0.1-1-any.pkg.tar.gz
 
+# the downloaded archive has a structure like `opt/devkitpro/portlibs/wii/{include,lib}/curl/...`, copy those files into `/opt/devkitpro/...`
 rsync -av --remove-source-files opt/devkitpro/ /opt/devkitpro/
-
-# brainslug
-git clone https://github.com/Chadderz121/brainslug-wii
-cd brainslug-wii
-make install
-cd ..
-rm -r brainslug-wii

--- a/runtime-ext/Makefile
+++ b/runtime-ext/Makefile
@@ -15,7 +15,7 @@ OFILES := $(addprefix build/,$(CFILES:.c=.o))
 # Prevent deletion of .o files, helps with incr rebuilds
 .SECONDARY: $(OFILES)
 
-INCLUDE := -I$(DEVKITPRO)/bslug/include -I../shared -Ivendor
+INCLUDE := -I../shared -Ivendor -Ivendor/bslug_include
 CFLAGS	:= -nostdlib -mno-eabi -O2 -Wall $(MACHDEP) $(INCLUDE)
 
 LINKERSCRIPTS := $(wildcard linker-*.ld)

--- a/runtime-ext/vendor/README.md
+++ b/runtime-ext/vendor/README.md
@@ -3,4 +3,4 @@ Some of the code was modified to work with our needs.
 To better preserve and view the difference between the original code and our modifications, the initial importing and any changes to it
 are always done in separate commits.
 
-- `libfat`, `libfat-sd`, `libsd` which are all modules part of [brainslug](https://github.com/Chadderz121/brainslug-wii)
+- `libfat`, `libfat-sd`, `libsd`, `bslug_include` which are all part of [brainslug](https://github.com/Chadderz121/brainslug-wii)

--- a/runtime-ext/vendor/bslug_include/ctype.h
+++ b/runtime-ext/vendor/bslug_include/ctype.h
@@ -1,0 +1,114 @@
+/* ctype.h
+ *   by Alex Chadwick
+ * 
+ * Copyright (C) 2014, Alex Chadwick
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* definitions of standard symbols in the ctype.h header file for which the
+ * brainslug symbol information is available. */
+
+#ifndef _CTYPE_H_
+#define _CTYPE_H_
+
+static inline int isalnum(int c);
+static inline int isalpha(int c);
+static inline int iscntrl(int c);
+static inline int isdigit(int c);
+static inline int isgraph(int c);
+static inline int islower(int c);
+static inline int isprint(int c);
+static inline int ispunct(int c);
+static inline int isspace(int c);
+static inline int isupper(int c);
+static inline int isxdigit(int c);
+
+static inline int tolower(int c);
+static inline int toupper(int c);
+
+enum ctype_t {
+    CTYPE_ISALPHA = 0x0001,
+    CTYPE_ISBLANK = 0x0002,
+    CTYPE_ISCNTRL = 0x0004,
+    CTYPE_ISDIGIT = 0x0008,
+    CTYPE_ISGRAPH = 0x0010,
+    CTYPE_ISLOWER = 0x0020,
+    CTYPE_ISPRINT = 0x0040,
+    CTYPE_ISPUNCT = 0x0080,
+    CTYPE_ISSPACE = 0x0100,
+    CTYPE_ISUPPER = 0x0200,
+    CTYPE_ISXDIGIT = 0x0400,
+    CTYPE_ISALNUM = CTYPE_ISALPHA | CTYPE_ISDIGIT
+};
+
+extern const short __ctype[256];
+extern const char  __lcase[256];
+extern const char  __ucase[256];
+
+static inline int isalnum(int c) {
+    return c >= 0 && c < sizeof(__ctype) && (__ctype[c] & CTYPE_ISALNUM);
+}
+static inline int isalpha(int c) {
+    return c >= 0 && c < sizeof(__ctype) && (__ctype[c] & CTYPE_ISALPHA);
+}
+static inline int isblank(int c) {
+    return c >= 0 && c < sizeof(__ctype) && (__ctype[c] & CTYPE_ISBLANK);
+}
+static inline int iscntrl(int c) {
+    return c >= 0 && c < sizeof(__ctype) && (__ctype[c] & CTYPE_ISCNTRL);
+}
+static inline int isdigit(int c) {
+    return c >= 0 && c < sizeof(__ctype) && (__ctype[c] & CTYPE_ISDIGIT);
+}
+static inline int isgraph(int c) {
+    return c >= 0 && c < sizeof(__ctype) && (__ctype[c] & CTYPE_ISGRAPH);
+}
+static inline int islower(int c) {
+    return c >= 0 && c < sizeof(__ctype) && (__ctype[c] & CTYPE_ISLOWER);
+}
+static inline int isprint(int c) {
+    return c >= 0 && c < sizeof(__ctype) && (__ctype[c] & CTYPE_ISPRINT);
+}
+static inline int ispunct(int c) {
+    return c >= 0 && c < sizeof(__ctype) && (__ctype[c] & CTYPE_ISPUNCT);
+}
+static inline int isspace(int c) {
+    return c >= 0 && c < sizeof(__ctype) && (__ctype[c] & CTYPE_ISSPACE);
+}
+static inline int isupper(int c) {
+    return c >= 0 && c < sizeof(__ctype) && (__ctype[c] & CTYPE_ISUPPER);
+}
+static inline int isxdigit(int c) {
+    return c >= 0 && c < sizeof(__ctype) && (__ctype[c] & CTYPE_ISXDIGIT);
+}
+
+static inline int tolower(int c) {
+    if (c < 0 || c >= sizeof(__lcase))
+        return c;
+    return __lcase[c];
+}
+static inline int toupper(int c) {
+    if (c < 0 || c >= sizeof(__ucase))
+        return c;
+    return __ucase[c];
+}
+
+
+#endif /* _CTYPE_H_ */

--- a/runtime-ext/vendor/bslug_include/errno.h
+++ b/runtime-ext/vendor/bslug_include/errno.h
@@ -1,0 +1,123 @@
+/* errno.h
+ *   by Alex Chadwick
+ * 
+ * Copyright (C) 2014, Alex Chadwick
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* definitions of standard symbols in the errno.h. These methods are provided in
+ * the libc module. */
+
+#ifndef _ERRNO_H_
+#define _ERRNO_H_
+
+#include <rvl/OSThread.h>
+
+#define errno (OSGetCurrentThread()->_errno)
+
+#define	EPERM 1		/* Not super-user */
+#define	ENOENT 2	/* No such file or directory */
+#define	ESRCH 3		/* No such process */
+#define	EINTR 4		/* Interrupted system call */
+#define	EIO 5		/* I/O error */
+#define	ENXIO 6		/* No such device or address */
+#define	E2BIG 7		/* Arg list too long */
+#define	ENOEXEC 8	/* Exec format error */
+#define	EBADF 9		/* Bad file number */
+#define	ECHILD 10	/* No children */
+#define	EAGAIN 11	/* No more processes */
+#define	ENOMEM 12	/* Not enough core */
+#define	EACCES 13	/* Permission denied */
+#define	EFAULT 14	/* Bad address */
+#define	EBUSY 16	/* Mount device busy */
+#define	EEXIST 17	/* File exists */
+#define	EXDEV 18	/* Cross-device link */
+#define	ENODEV 19	/* No such device */
+#define	ENOTDIR 20	/* Not a directory */
+#define	EISDIR 21	/* Is a directory */
+#define	EINVAL 22	/* Invalid argument */
+#define	ENFILE 23	/* Too many open files in system */
+#define	EMFILE 24	/* Too many open files */
+#define	ENOTTY 25	/* Not a typewriter */
+#define	ETXTBSY 26	/* Text file busy */
+#define	EFBIG 27	/* File too large */
+#define	ENOSPC 28	/* No space left on device */
+#define	ESPIPE 29	/* Illegal seek */
+#define	EROFS 30	/* Read only file system */
+#define	EMLINK 31	/* Too many links */
+#define	EPIPE 32	/* Broken pipe */
+#define	EDOM 33		/* Math arg out of domain of func */
+#define	ERANGE 34	/* Math result not representable */
+#define	ENOMSG 35	/* No message of desired type */
+#define	EIDRM 36	/* Identifier removed */
+#define	EDEADLK 45	/* Deadlock condition */
+#define	ENOLCK 46	/* No record locks available */
+#define ENOSTR 60	/* Device not a stream */
+#define ENODATA 61	/* No data (for no delay io) */
+#define ETIME 62	/* Timer expired */
+#define ENOSR 63	/* Out of streams resources */
+#define ENOLINK 67	/* The link has been severed */
+#define EPROTO 71	/* Protocol error */
+#define	EMULTIHOP 74	/* Multihop attempted */
+#define EBADMSG 77	/* Trying to read unreadable message */
+#define EFTYPE 79	/* Inappropriate file type or format */
+#define ENOSYS 88	/* Function not implemented */
+#define ENOTEMPTY 90	/* Directory not empty */
+#define ENAMETOOLONG 91	/* File or path name too long */
+#define ELOOP 92	/* Too many symbolic links */
+#define EOPNOTSUPP 95	/* Operation not supported on transport endpoint */
+#define EPFNOSUPPORT 96 /* Protocol family not supported */
+#define ECONNRESET 104  /* Connection reset by peer */
+#define ENOBUFS 105	/* No buffer space available */
+#define EAFNOSUPPORT 106 /* Address family not supported by protocol family */
+#define EPROTOTYPE 107	/* Protocol wrong type for socket */
+#define ENOTSOCK 108	/* Socket operation on non-socket */
+#define ENOPROTOOPT 109	/* Protocol not available */
+#define ECONNREFUSED 111	/* Connection refused */
+#define EADDRINUSE 112		/* Address already in use */
+#define ECONNABORTED 113	/* Connection aborted */
+#define ENETUNREACH 114		/* Network is unreachable */
+#define ENETDOWN 115		/* Network interface is not configured */
+#define ETIMEDOUT 116		/* Connection timed out */
+#define EHOSTDOWN 117		/* Host is down */
+#define EHOSTUNREACH 118	/* Host is unreachable */
+#define EINPROGRESS 119		/* Connection already in progress */
+#define EALREADY 120		/* Socket already connected */
+#define EDESTADDRREQ 121	/* Destination address required */
+#define EMSGSIZE 122		/* Message too long */
+#define EPROTONOSUPPORT 123	/* Unknown protocol */
+#define EADDRNOTAVAIL 125	/* Address not available */
+#define ENETRESET 126
+#define EISCONN 127		/* Socket is already connected */
+#define ENOTCONN 128		/* Socket is not connected */
+#define ETOOMANYREFS 129
+#define EDQUOT 132
+#define ESTALE 133
+#define ENOTSUP 134		/* Not supported */
+#define EILSEQ 138
+#define EOVERFLOW 139	/* Value too large for defined data type */
+#define ECANCELED 140	/* Operation canceled */
+#define ENOTRECOVERABLE 141	/* State not recoverable */
+#define EOWNERDEAD 142	/* Previous owner died */
+#define EWOULDBLOCK EAGAIN	/* Operation would block */
+
+#define __ELASTERROR 2000	/* Users can add values starting here */
+
+#endif /* _ERRNO_H_ */

--- a/runtime-ext/vendor/bslug_include/fcntl.h
+++ b/runtime-ext/vendor/bslug_include/fcntl.h
@@ -1,6 +1,6 @@
-/* main.c
+/* errno.h
  *   by Alex Chadwick
- *
+ * 
  * Copyright (C) 2014, Alex Chadwick
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,4 +22,32 @@
  * SOFTWARE.
  */
 
-#include <io/libsd.h>
+/* definitions of standard symbols in the fcntl.h. These methods are
+ * provided in the libc module. */
+
+#ifndef _FCNTL_H_
+#define _FCNTL_H_
+
+#define _FREAD      0x0001  /* read enabled */
+#define _FWRITE     0x0002  /* write enabled */
+#define _FAPPEND    0x0008  /* append (writes guaranteed at the end) */
+#define _FCREAT     0x0200  /* open with file create */
+#define _FTRUNC     0x0400  /* open with truncation */
+#define _FEXCL      0x0800  /* error on open if file exists */
+#define _FSYNC      0x2000  /* do all writes synchronously */
+
+#define O_RDONLY    0
+#define O_WRONLY    1
+#define O_RDWR      2
+#define O_APPEND    _FAPPEND
+#define O_CREAT     _FCREAT
+#define O_TRUNC     _FTRUNC
+#define O_EXCL      _FEXCL
+#define O_SYNC      _FSYNC
+
+#define O_NONBLOCK  0x0800 /* non blocking (sockets only) */
+
+#define F_GETFL     3   /* Get file flags */
+#define F_SETFL     4   /* Set file flags */
+
+#endif /* _FCNTL_H_ */

--- a/runtime-ext/vendor/bslug_include/io/disc_io.h
+++ b/runtime-ext/vendor/bslug_include/io/disc_io.h
@@ -1,0 +1,69 @@
+/*
+ disc_io.h
+ Interface template for low level disc functions.
+ 
+ Edited 2014 by Alex Chadwick for inclusion in bslug
+ Copyright (c) 2006 Michael "Chishm" Chisholm
+ Based on code originally written by MightyMax
+	
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation and/or
+     other materials provided with the distribution.
+  3. The name of the author may not be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef OGC_DISC_IO_INCLUDE
+#define OGC_DISC_IO_INCLUDE
+
+#include <stdbool.h>
+#include <stdint.h>
+
+
+#define FEATURE_MEDIUM_CANREAD      0x00000001
+#define FEATURE_MEDIUM_CANWRITE     0x00000002
+#define FEATURE_GAMECUBE_SLOTA      0x00000010
+#define FEATURE_GAMECUBE_SLOTB      0x00000020
+#define FEATURE_GAMECUBE_DVD        0x00000040
+#define FEATURE_WII_SD              0x00000100
+#define FEATURE_WII_USB             0x00000200
+#define FEATURE_WII_DVD             0x00000400
+
+typedef uint32_t sec_t;
+
+typedef bool (* FN_MEDIUM_STARTUP)(void) ;
+typedef bool (* FN_MEDIUM_ISINSERTED)(void) ;
+typedef bool (* FN_MEDIUM_READSECTORS)(sec_t sector, sec_t numSectors, void* buffer) ;
+typedef bool (* FN_MEDIUM_WRITESECTORS)(sec_t sector, sec_t numSectors, const void* buffer) ;
+typedef bool (* FN_MEDIUM_CLEARSTATUS)(void) ;
+typedef bool (* FN_MEDIUM_SHUTDOWN)(void) ;
+
+struct DISC_INTERFACE_STRUCT {
+	unsigned long			ioType ;
+	unsigned long			features ;
+	FN_MEDIUM_STARTUP		startup ;
+	FN_MEDIUM_ISINSERTED	isInserted ;
+	FN_MEDIUM_READSECTORS	readSectors ;
+	FN_MEDIUM_WRITESECTORS	writeSectors ;
+	FN_MEDIUM_CLEARSTATUS	clearStatus ;
+	FN_MEDIUM_SHUTDOWN		shutdown ;
+} ;
+
+typedef struct DISC_INTERFACE_STRUCT DISC_INTERFACE ;
+
+#endif	// define OGC_DISC_IO_INCLUDE

--- a/runtime-ext/vendor/bslug_include/io/fat-sd.h
+++ b/runtime-ext/vendor/bslug_include/io/fat-sd.h
@@ -1,0 +1,204 @@
+/* io/fat-sd.h
+ *   by Alex Chadwick
+ * 
+ * Copyright (C) 2014, Alex Chadwick
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* A simple helper-wrapper around libfat and libsd to allow mounting and using
+ * of FAT formatted sd cards. */
+
+#ifndef _IO_FAT_SD_H_
+#define _IO_FAT_SD_H_
+
+#include <io/fat.h>
+#include <io/libsd.h>
+
+/* Call this before any other methods. The first module to call SD_Mount
+ * performs that actual FAT mounting procedure. Returns 0 on sucess. Sets errno.
+ */
+int SD_Mount(void);
+
+/******************************************************************************/
+/* File handling */
+
+/* Open a file.
+ *  fileStruct - buffer to store file information in.
+ *  path       - path of file.
+ *  flags      - open flags from <fcntl.h> O_RDONLY, O_RDWR, O_WRONLY, O_CREAT,
+ *               O_APPEND, O_TRUNC
+ * Returns -1 on error or a fd for use in other file calls. Sets errno. */
+static inline int SD_open(FILE_STRUCT *fileStruct, const char *path, int flags);
+/* Close a file and synch to device. Returns 0 on success. */
+static inline int SD_close(int fd);
+/* Write to a file.
+ * Returns number of bytes successfully written (or -1 on error). Sets errno. */
+static inline ssize_t SD_write(int fd, const char *ptr, size_t len);
+/* Read from a file.
+ * Returns number of bytes successfully read (or -1 on error). Sets errno. */
+static inline ssize_t SD_read(int fd, char *ptr, size_t len);
+/* Seek within file. dir is one of SEEK_SET, SEEK_CUR or SEEK_END (stdio.h).
+ * Returns new absolute position (or -1 on error). Sets errno. */
+static inline off_t SD_seek(int fd, off_t pos, int dir);
+
+/* Shortens (or expands) a file to specified length.
+ * Returns 0 on success. Sets errno. */
+static inline int SD_ftruncate(int fd, off_t len);
+/* Synchronises a file to the device. This call does not return until all
+ * prior write calls to this file have been sent to the device.
+ * Returns 0 on success. Sets errno. */
+static inline int SD_fsync(int fd);
+/* Fills in the st buffer with metadata about the file.
+ * Returns 0 on success. Sets errno. */
+static inline int SD_fstat(int fd, struct stat *st);
+
+/******************************************************************************/
+/* File system manipulation */
+
+/* Gets the DOS file attributes of the specified file.
+ * Returns -1 on error. Does not set errno. */
+static inline FILE_ATTR SD_getAttr(const char *file);
+/* Sets the DOS file attributes of the specified file.
+ * Returns 0 on success. Does not set errno. */
+static inline int SD_setAttr(const char *file, FILE_ATTR attr);
+
+/* Fills in the st buffer with metadata about the specified file.
+ * Returns 0 on success. Sets errno. */
+static inline int SD_stat(const char *path, struct stat *st);
+/* Fills in the st buffer with metadata about the specified filesystem.
+ * Returns 0 on success. Sets errno. */
+static inline int SD_statvfs(const char *path, struct statvfs *buf);
+
+/* Deletes the specified file.
+ * Returns 0 on success. Sets errno. */
+static inline int SD_unlink(const char *name);
+/* Renames (or moves) a file from one name to another.
+ * Returns 0 on success. Sets errno. */
+static inline int SD_rename(const char *oldName, const char *newName);
+
+/* Sets the path for all future relative file paths.
+ * Returns 0 on success. Sets errno. */
+static inline int SD_chdir(const char *name);
+
+/* Creates the specified directory.
+ * Returns 0 on success. Sets errno. */
+static inline int SD_mkdir(const char *path);
+
+/******************************************************************************/
+/* Directory listing */
+
+/* Opens a directory for listing purposes.
+ *  state     - buffer in which to store directory information.
+ *  path      - path to the directory.
+ * Returns NULL on error. Sets errno. */
+static inline DIR_STATE_STRUCT* SD_diropen(
+    DIR_STATE_STRUCT *state, const char *path);
+/* Resets a directory iterator.
+ * Returns 0 on success. Sets errno. */
+static inline int SD_dirreset(DIR_STATE_STRUCT *state);
+/* Moves to the next file in a directory.
+ *  state    - iterator to advance
+ *  filename - buffer in which to store name of next file. Will not exceed
+ *             MAX_FILENAME_LENGTH.
+ *  filestat - buffer in which to store metadata about the next file.
+ * Returns 0 on success. Sets errno.
+ * Returns -1 and sets errno to ENOENT if no more files avilable. */
+static inline int SD_dirnext(
+    DIR_STATE_STRUCT *state, char *filename, struct stat *filestat);
+/* Closes a directory iterator.
+ * Returns 0 on success. Sets errno. */
+static inline int SD_dirclose(DIR_STATE_STRUCT *state);
+
+/******************************************************************************/
+
+extern PARTITION sd_partition;
+
+static inline int SD_open(
+        FILE_STRUCT *fileStruct, const char *path, int flags) {
+    return FAT_open(fileStruct, &sd_partition, path, flags);
+}
+static inline int SD_close(int fd) {
+    return FAT_close(fd);
+}
+static inline ssize_t SD_write(int fd, const char *ptr, size_t len) {
+    return FAT_write(fd, ptr, len);
+}
+static inline ssize_t SD_read(int fd, char *ptr, size_t len) {
+    return FAT_read(fd, ptr, len);
+}
+static inline off_t SD_seek(int fd, off_t pos, int dir) {
+    return FAT_seek(fd, pos, dir);
+}
+
+static inline int SD_ftruncate(int fd, off_t len) {
+    return FAT_ftruncate(fd, len);
+}
+static inline int SD_fsync(int fd) {
+    return FAT_fsync(fd);
+}
+static inline int SD_fstat(int fd, struct stat *st) {
+    return FAT_fstat(fd, st);
+}
+
+static inline FILE_ATTR SD_getAttr(const char *file) {
+    return FAT_getAttr(&sd_partition, file);
+}
+static inline int SD_setAttr(const char *file, FILE_ATTR attr) {
+    return FAT_setAttr(&sd_partition, file, attr);
+}
+
+static inline int SD_stat(const char *path, struct stat *st) {
+    return FAT_stat(&sd_partition, path, st);
+}
+static inline int SD_statvfs(const char *path, struct statvfs *buf) {
+    return FAT_statvfs(&sd_partition, path, buf);
+}
+
+static inline int SD_unlink(const char *name) {
+    return FAT_unlink(&sd_partition, name);
+}
+static inline int SD_rename(const char *oldName, const char *newName) {
+    return FAT_rename(&sd_partition, oldName, newName);
+}
+
+static inline int SD_chdir(const char *name) {
+    return FAT_chdir(&sd_partition, name);
+}
+
+static inline int SD_mkdir(const char *path) {
+    return FAT_mkdir(&sd_partition, path);
+}
+
+static inline DIR_STATE_STRUCT* SD_diropen(
+        DIR_STATE_STRUCT *state, const char *path) {
+    return FAT_diropen(state, &sd_partition, path);
+}
+static inline int SD_dirreset(DIR_STATE_STRUCT *state) {
+    return FAT_dirreset(state);
+}
+static inline int SD_dirnext(
+        DIR_STATE_STRUCT *state, char *filename, struct stat *filestat) {
+    return FAT_dirnext(state, filename, filestat);
+}
+static inline int SD_dirclose(DIR_STATE_STRUCT *state) {
+    return FAT_dirclose(state);
+}
+
+#endif /* _IO_FAT_SD_H_ */

--- a/runtime-ext/vendor/bslug_include/io/fat.h
+++ b/runtime-ext/vendor/bslug_include/io/fat.h
@@ -1,0 +1,275 @@
+/*
+	fat.h
+	Simple functionality for startup, mounting and unmounting of FAT-based devices.
+	
+ Copyright (c) 2006 - 2014
+	Michael "Chishm" Chisholm
+	Dave "WinterMute" Murphy
+    Alex "Chadderz" Chadwick
+
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation and/or
+     other materials provided with the distribution.
+  3. The name of the author may not be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+#ifndef _LIBFAT_H
+#define _LIBFAT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "libfatversion.h"
+
+#include <io/disc_io.h>
+#include <rvl/OSMutex.h>
+#include <stdint.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <sys/types.h>
+
+/* A note on file paths:
+ *  / is the root directory.
+ *  Device names like sd:/ will be ignored. */ 
+
+typedef struct PARTITION PARTITION;
+typedef struct _FILE_STRUCT FILE_STRUCT;
+typedef struct DIR_STATE_STRUCT DIR_STATE_STRUCT;
+typedef enum FILE_ATTR FILE_ATTR;
+
+/******************************************************************************/
+/* Partition handling */
+
+/* Mount the supplied device's partition.
+ *  disc        - device to mount
+ *  partition   - buffer to fill partition data in
+ *  cacheSpace  - buffer to create cache in (at least 16kb)
+ *  cacheSize   - size of cacheSpace buffer
+ *  startSector - first sector of partition [0 unless you know otherwise]
+ * Returns NULL on error. */
+PARTITION *FAT_partition_constructor(
+    const DISC_INTERFACE* disc, PARTITION *partition, uint8_t *cacheSpace,
+    size_t cacheSize, sec_t startSector);
+/* Dismount the device and synchronise all open files to disc. */
+void FAT_partition_destructor(PARTITION* partition);
+
+/******************************************************************************/
+/* File handling */
+
+/* Open a file.
+ *  fileStruct - buffer to store file information in.
+ *  partition  - partition to open file in.
+ *  path       - path of file.
+ *  flags      - open flags from <fcntl.h> O_RDONLY, O_RDWR, O_WRONLY, O_CREAT,
+ *               O_APPEND, O_TRUNC
+ * Returns -1 on error or a fd for use in other file calls. Sets errno. */
+int FAT_open(
+    FILE_STRUCT *fileStruct, PARTITION *partition, const char *path, int flags);
+/* Close a file and synch to device. Returns 0 on success. */
+int FAT_close(int fd);
+/* Write to a file.
+ * Returns number of bytes successfully written (or -1 on error). Sets errno. */
+ssize_t FAT_write(int fd, const char *ptr, size_t len);
+/* Read from a file.
+ * Returns number of bytes successfully read (or -1 on error). Sets errno. */
+ssize_t FAT_read(int fd, char *ptr, size_t len);
+/* Seek within file. dir is one of SEEK_SET, SEEK_CUR or SEEK_END (stdio.h).
+ * Returns new absolute position (or -1 on error). Sets errno. */
+off_t FAT_seek(int fd, off_t pos, int dir);
+
+/* Shortens (or expands) a file to specified length.
+ * Returns 0 on success. Sets errno. */
+int FAT_ftruncate(int fd, off_t len);
+/* Synchronises a file to the device. This call does not return until all
+ * prior write calls to this file have been sent to the device.
+ * Returns 0 on success. Sets errno. */
+int FAT_fsync(int fd);
+/* Fills in the st buffer with metadata about the file.
+ * Returns 0 on success. Sets errno. */
+int FAT_fstat(int fd, struct stat *st);
+
+/******************************************************************************/
+/* File system manipulation */
+
+enum FILE_ATTR {
+    ATTR_ARCHIVE	= 0x20,			/* Archive */
+    ATTR_DIRECTORY	= 0x10,			/* Directory */
+    ATTR_VOLUME		= 0x08,			/* Volume */
+    ATTR_SYSTEM		= 0x04,			/* System */
+    ATTR_HIDDEN		= 0x02,			/* Hidden */
+    ATTR_READONLY	= 0x01			/* Read only */
+};
+
+/* Gets the DOS file attributes of the specified file.
+ * Returns -1 on error. Does not set errno. */
+FILE_ATTR FAT_getAttr(PARTITION *partition, const char *file);
+/* Sets the DOS file attributes of the specified file.
+ * Returns 0 on success. Does not set errno. */
+int FAT_setAttr(PARTITION *partition, const char *file, FILE_ATTR attr);
+
+/* Fills in the st buffer with metadata about the specified file.
+ * Returns 0 on success. Sets errno. */
+int FAT_stat(PARTITION *partition, const char *path, struct stat *st);
+/* Fills in the st buffer with metadata about the specified filesystem.
+ * Returns 0 on success. Sets errno. */
+int FAT_statvfs(PARTITION *partition, const char *path, struct statvfs *buf);
+
+/* Deletes the specified file.
+ * Returns 0 on success. Sets errno. */
+int FAT_unlink(PARTITION *partition, const char *name);
+/* Renames (or moves) a file from one name to another.
+ * Returns 0 on success. Sets errno. */
+int FAT_rename(PARTITION *partition, const char *oldName, const char *newName);
+
+/* Sets the path for all future relative file paths.
+ * Returns 0 on success. Sets errno. */
+int FAT_chdir(PARTITION *partition, const char *name);
+
+/* Creates the specified directory.
+ * Returns 0 on success. Sets errno. */
+int FAT_mkdir(PARTITION *partition, const char *path);
+
+/******************************************************************************/
+/* Directory listing */
+
+/* Opens a directory for listing purposes.
+ *  state     - buffer in which to store directory information.
+ *  partition - partition on which the directory resides.
+ *  path      - path to the directory.
+ * Returns NULL on error. Sets errno. */
+DIR_STATE_STRUCT* FAT_diropen(
+    DIR_STATE_STRUCT *state, PARTITION *partition, const char *path);
+/* Resets a directory iterator.
+ * Returns 0 on success. Sets errno. */
+int FAT_dirreset(DIR_STATE_STRUCT *state);
+/* Moves to the next file in a directory.
+ *  state    - iterator to advance
+ *  filename - buffer in which to store name of next file. Will not exceed
+ *             MAX_FILENAME_LENGTH.
+ *  filestat - buffer in which to store metadata about the next file.
+ * Returns 0 on success. Sets errno.
+ * Returns -1 and sets errno to ENOENT if no more files avilable. */
+int FAT_dirnext(DIR_STATE_STRUCT *state, char *filename, struct stat *filestat);
+/* Closes a directory iterator.
+ * Returns 0 on success. Sets errno. */
+int FAT_dirclose(DIR_STATE_STRUCT *state);
+
+/******************************************************************************/
+/* Avoid directly reading or modifying any of these structures. */
+
+#define LIBFAT_FEOS_MULTICWD
+
+// Filesystem type
+typedef enum {FS_UNKNOWN, FS_FAT12, FS_FAT16, FS_FAT32} FS_TYPE;
+
+typedef struct {
+	sec_t    fatStart;
+	uint32_t sectorsPerFat;
+	uint32_t lastCluster;
+	uint32_t firstFree;
+	uint32_t numberFreeCluster;
+	uint32_t numberLastAllocCluster;
+} FAT;
+
+struct CACHE;
+struct _FILE_STRUCT;
+
+struct PARTITION {
+	const DISC_INTERFACE* disc;
+	struct CACHE*         cache;
+	// Info about the partition
+	FS_TYPE               filesysType;
+	uint64_t              totalSize;
+	sec_t                 rootDirStart;
+	uint32_t              rootDirCluster;
+	uint32_t              numberOfSectors;
+	sec_t                 dataStart;
+	uint32_t              bytesPerSector;
+	uint32_t              sectorsPerCluster;
+	uint32_t              bytesPerCluster;
+	uint32_t              fsInfoSector;
+	FAT                   fat;
+	// Values that may change after construction
+	uint32_t              cwdCluster;			// Current working directory cluster
+	int                   openFileCount;
+	struct _FILE_STRUCT*  firstOpenFile;		// The start of a linked list of files
+	OSMutex_t             lock;					// A lock for partition operations
+	bool                  readOnly;				// If this is set, then do not try writing to the disc
+	char                  label[12];			// Volume label
+};
+
+#define FILE_MAX_SIZE ((uint32_t)0xFFFFFFFF)	// 4GiB - 1B
+
+typedef struct {
+	uint32_t cluster;
+	sec_t sector;
+	int32_t byte;
+} FILE_POSITION;
+
+typedef struct {
+	uint32_t cluster;
+	sec_t    sector;
+	int32_t  offset;
+} DIR_ENTRY_POSITION;
+
+struct _FILE_STRUCT {
+	uint32_t             filesize;
+	uint32_t             startCluster;
+	uint32_t             currentPosition;
+	FILE_POSITION        rwPosition;
+	FILE_POSITION        appendPosition;
+	DIR_ENTRY_POSITION   dirEntryStart;		// Points to the start of the LFN entries of a file, or the alias for no LFN
+	DIR_ENTRY_POSITION   dirEntryEnd;		// Always points to the file's alias entry
+	PARTITION*           partition;
+	struct _FILE_STRUCT* prevOpenFile;		// The previous entry in a double-linked list of open files
+	struct _FILE_STRUCT* nextOpenFile;		// The next entry in a double-linked list of open files
+	bool                 read;
+	bool                 write;
+	bool                 append;
+	bool                 inUse;
+	bool                 modified;
+};
+
+typedef enum {FT_DIRECTORY, FT_FILE} FILE_TYPE;
+
+#define DIR_ENTRY_DATA_SIZE 0x20
+#define MAX_FILENAME_LENGTH 768		// 256 UCS-2 characters encoded into UTF-8 can use up to 768 UTF-8 chars
+
+typedef struct {
+	uint8_t            entryData[DIR_ENTRY_DATA_SIZE];
+	DIR_ENTRY_POSITION dataStart;		// Points to the start of the LFN entries of a file, or the alias for no LFN
+	DIR_ENTRY_POSITION dataEnd;			// Always points to the file/directory's alias entry
+	char               filename[MAX_FILENAME_LENGTH];
+} DIR_ENTRY;
+
+typedef struct DIR_STATE_STRUCT {
+	PARTITION* partition;
+	DIR_ENTRY  currentEntry;
+	uint32_t   startCluster;
+	bool       inUse;
+	bool       validEntry;
+} DIR_STATE_STRUCT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _LIBFAT_H

--- a/runtime-ext/vendor/bslug_include/io/libfatversion.h
+++ b/runtime-ext/vendor/bslug_include/io/libfatversion.h
@@ -1,0 +1,10 @@
+#ifndef __LIBFATVERSION_H__
+#define __LIBFATVERSION_H__
+
+#define _LIBFAT_MAJOR_	1
+#define _LIBFAT_MINOR_	0
+#define _LIBFAT_PATCH_	12
+
+#define _LIBFAT_STRING "libFAT Release 1.0.12"
+
+#endif // __LIBFATVERSION_H__

--- a/runtime-ext/vendor/bslug_include/io/libsd.h
+++ b/runtime-ext/vendor/bslug_include/io/libsd.h
@@ -1,0 +1,44 @@
+/*
+
+  wii_sd.h
+
+  Hardware interface for libfat Wii internal SD
+
+ Copyright (c) 2008 - 2014
+   Michael Wiedenbauer (shagkur)
+   Dave Murphy (WinterMute)
+   Alex Chadwick (Chadderz)
+
+	
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation and/or
+     other materials provided with the distribution.
+  3. The name of the author may not be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef __WIISD_IO_H__
+#define __WIISD_IO_H__
+
+#include <io/disc_io.h>
+
+#define DEVICE_TYPE_WII_SD (('W'<<24)|('I'<<16)|('S'<<8)|'D')
+
+extern const DISC_INTERFACE __io_wiisd;
+
+#endif

--- a/runtime-ext/vendor/bslug_include/rvl/OSMutex.h
+++ b/runtime-ext/vendor/bslug_include/rvl/OSMutex.h
@@ -1,0 +1,75 @@
+/* OSMutex.h
+ *   by Alex Chadwick
+ * 
+ * Copyright (C) 2014, Alex Chadwick
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* definitions of symbols inferred to exist in the OSMutex.h header file for
+ * which the brainslug symbol information is available. */
+
+#ifndef _RVL_OSMUTEX_H_
+#define _RVL_OSMUTEX_H_
+
+#include <stdbool.h>
+#include <rvl/OSThread.h>
+
+typedef struct OSMutex_t OSMutex_t;
+typedef struct OSCond_t OSCond_t;
+
+/* Helpful observation: OSInitMutex and OSInitCond just zero their parameters.
+ * Thus you don't _HAVE_ to init a mutex, you can just zero it. */
+
+static inline void OSInitMutex(OSMutex_t *mutex);
+void OSLockMutex(OSMutex_t *mutex);
+void OSUnlockMutex(OSMutex_t *mutex);
+bool OSTryLockMutex(OSMutex_t *mutex);
+
+static inline void OSInitCond(OSCond_t *cond);
+/* mutex cannot be NULL */
+void OSWaitCond(OSCond_t *cond, OSMutex_t *mutex);
+static inline void OSSignalCond(OSCond_t *cond);
+
+struct OSMutex_t {
+    OSThreadQueue_t queue;
+    OSThread_t *lock_holder;
+    int lock_count;
+    OSMutex_t *next_held_next;
+    OSMutex_t *next_held_prev;
+};
+
+static inline void OSInitMutex(OSMutex_t *mutex) {
+    OSInitThreadQueue(&mutex->queue);
+    mutex->lock_holder = NULL;
+    mutex->lock_count = 0;
+}
+
+struct OSCond_t {
+    OSThreadQueue_t queue;
+};
+
+static inline void OSInitCond(OSCond_t *cond) {
+    OSInitThreadQueue(&cond->queue);    
+}
+static inline void OSSignalCond(OSCond_t *cond) {
+    OSWakeupThread(&cond->queue);
+}
+
+#endif /* _RVL_OSMUTEX_H_ */

--- a/runtime-ext/vendor/bslug_include/rvl/OSThread.h
+++ b/runtime-ext/vendor/bslug_include/rvl/OSThread.h
@@ -1,0 +1,105 @@
+/* OSThread.h
+ *   by Alex Chadwick
+ * 
+ * Copyright (C) 2014, Alex Chadwick
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* definitions of symbols inferred to exist in the OSThread header file for
+ * which the brainslug symbol information is available. */
+
+#ifndef _RVL_OSTHREAD_H_
+#define _RVL_OSTHREAD_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct OSThread_t OSThread_t;
+typedef struct OSThreadQueue_t OSThreadQueue_t;
+typedef struct OSMutex_t OSMutex_t;
+typedef void *(*OSThreadEntry_t)(void *argument);
+
+#define THREAD_PRIORITY_LOWEST 0
+#define THREAD_PRIORITY_HIGHEST 31
+
+static inline void OSInitThreadQueue(OSThreadQueue_t *queue);
+OSThread_t *OSGetCurrentThread(void);
+bool OSIsThreadTerminated(OSThread_t *thread);
+bool OSCreateThread(
+    OSThread_t *thread, OSThreadEntry_t entry_point, void *argument,
+    void *stack_base, size_t stack_size, int priority, bool detached);
+void OSExitThread(void *exit_code);
+void OSCancelThread(OSThread_t *thread);
+void OSSleepThread(OSThreadQueue_t *queue);
+void OSWakeupThread(OSThreadQueue_t *queue);
+bool OSSetThreadPriority(OSThread_t *thread, int priority);
+static inline int OSGetThreadPriority(OSThread_t *thread);
+
+struct OSThreadQueue_t {
+    OSThread_t *_unknown0;
+    OSThread_t *_unknown4;
+};
+
+static inline void OSInitThreadQueue(OSThreadQueue_t *queue) {
+    queue->_unknown0 = NULL;
+    queue->_unknown4 = NULL;
+}
+
+struct OSThread_t {
+  uint32_t gpr[32]; /* 0x0 from OSLoadContext */
+  uint32_t cr; /* 0x80 from OSLoadContext */
+  uint32_t lr; /* 0x84 from OSLoadContext */
+  uint32_t ctr; /* 0x88 from OSLoadContext */
+  uint32_t xer; /* 0x8c from OSLoadContext */
+  double fpr[32]; /* 0x90 from guesswork */
+  char _unknown190[0x198 - 0x190];
+  uint32_t srr0; /* 0x198 from OSLoadContext */
+  uint32_t srr1; /* 0x19c from OSLoadContext */
+  char _unknown1a0[0x1a2 - 0x1a0];
+  struct {
+    unsigned : 1; /* 15 */
+    unsigned restore_volatile_gpr : 1; /* 14 from OSCreateThread; whether or not to restore volatile gprs */
+    unsigned : 14; /* 0-13 */
+  } ctx_flags; /* 0x1a2 from OSLoadContext */
+  uint32_t gqr[8]; /* 0x1a4 from OSLoadContext */
+  char _unknown1c4[0x2ca - 0x1c4];
+  short state; /* 0x2c8 from OSIsThreadTerminated */
+  short param_r9; /* 0x2ca from OSCreateThread */
+  int param_stack_size; /* 0x2cc from OSCreateThread */
+  int param_priorty; /* 0x2d0 from OSCreateThread */
+  int priority; /* 0x2d4 from OSGetThreadPriority */
+  void *exit_code; /* 0x2d8 from OSExitThread */
+  OSThreadQueue_t *sleep_queue; /* 0x2dc from OSSleepThread */
+  char _unknown2e0[0x2e8 - 0x2e0];
+  OSThreadQueue_t _unknown2e8; /* 0x2e8 from OSDetachThread */
+  OSMutex_t *mutex_waiting; /* 0x2f0 from OSLockMutex */
+  OSMutex_t *mutex_held_first; /* 0x2f4 from __OSUnlockAllMutex */
+  OSMutex_t *mutex_held_last; /* 0x2f8 from __OSUnlockAllMutex */
+  char _unknown2fc[0x30c - 0x2fc];
+  int _errno; /* 0x30c Guess from networking */
+  char _unknown310[0x318 - 0x310];
+};
+
+static inline int OSGetThreadPriority(OSThread_t *thread) {
+    return thread->priority;
+}
+
+#endif /* _RVL_OSTHREAD_H_ */

--- a/runtime-ext/vendor/bslug_include/rvl/OSTime.h
+++ b/runtime-ext/vendor/bslug_include/rvl/OSTime.h
@@ -1,0 +1,65 @@
+/* OSTime.h
+ *   by Alex Chadwick
+ * 
+ * Copyright (C) 2014, Alex Chadwick
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* definitions of symbols inferred to exist in the OSTime header file for
+ * which the brainslug symbol information is available. */
+
+#ifndef _RVL_OSTIME_H_
+#define _RVL_OSTIME_H_
+
+#include <stdint.h>
+
+typedef struct {
+    int32_t tm_sec;
+    int32_t tm_min;
+    int32_t tm_hour;
+    int32_t tm_mday;
+    int32_t tm_mon;
+    int32_t tm_year;
+    int32_t tm_wday;
+    int32_t tm_yday;
+    int32_t tm_msec;
+    int32_t tm_usec;
+} OSCalendarTime_t;
+
+uint64_t OSGetTime(void);
+uint32_t OSGetTick(void);
+void OSTicksToCalendarTime(uint64_t ticks, OSCalendarTime_t *time);
+
+#define TB_BUS_CLOCK				243000000u
+#define TB_CORE_CLOCK				729000000u
+#define TB_TIMER_CLOCK				(TB_BUS_CLOCK/4000)	
+
+#define ticks_to_secs(ticks)		(((ticks)/(TB_TIMER_CLOCK*1000)))
+#define ticks_to_millisecs(ticks)	(((ticks)/(TB_TIMER_CLOCK)))
+#define ticks_to_microsecs(ticks)	((((ticks)*8)/(TB_TIMER_CLOCK/125)))
+#define ticks_to_nanosecs(ticks)	((((ticks)*8000)/(TB_TIMER_CLOCK/125)))
+
+#define secs_to_ticks(sec)			((sec)*(TB_TIMER_CLOCK*1000))
+#define millisecs_to_ticks(msec)	((msec)*(TB_TIMER_CLOCK))
+#define microsecs_to_ticks(usec)	(((usec)*(TB_TIMER_CLOCK/125))/8)
+#define nanosecs_to_ticks(nsec)		(((nsec)*(TB_TIMER_CLOCK/125))/8000)
+
+
+#endif /* _RVL_OSTIME_H_ */

--- a/runtime-ext/vendor/bslug_include/rvl/OSUtf.h
+++ b/runtime-ext/vendor/bslug_include/rvl/OSUtf.h
@@ -1,6 +1,6 @@
-/* main.c
+/* OSUtf.h
  *   by Alex Chadwick
- *
+ * 
  * Copyright (C) 2014, Alex Chadwick
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,4 +22,19 @@
  * SOFTWARE.
  */
 
-#include <io/libsd.h>
+/* definitions of symbols inferred to exist in the OSUtf.h header file for
+ * which the brainslug symbol information is available. */
+
+#ifndef _RVL_OSUTF_H_
+#define _RVL_OSUTF_H_
+
+/* Converts the utf8 encoded character at utf8 to a 32 bit utf32 integer and
+ * stores it at utf32. Returns utf8 advanced by the number of characters read on
+ * success, or NULL on error. If utf8 points to the NULL character, it returns
+ * utf8. */
+char *OSUTF8to32(const char *utf8, int *utf32);
+/* Converts the utf32 character to a single byte ANSI character. Returns '\0' on
+ * error. */
+char OSUTF32toANSI(int utf32);
+
+#endif /* _RVL_OSUTF_H_ */

--- a/runtime-ext/vendor/bslug_include/rvl/cache.h
+++ b/runtime-ext/vendor/bslug_include/rvl/cache.h
@@ -1,6 +1,6 @@
-/* main.c
+/* rvl/cache.h
  *   by Alex Chadwick
- *
+ * 
  * Copyright (C) 2014, Alex Chadwick
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,4 +22,16 @@
  * SOFTWARE.
  */
 
-#include <io/libsd.h>
+/* definitions of standard symbols typically in the ogc/cache.h header file for
+ * which the brainslug symbol information is available. */
+ 
+#ifndef _RVL_CACHE_H_
+#define _RVL_CACHE_H_
+
+#include <stddef.h> /* for size_t */
+
+void DCFlushRange(const void *start, size_t length);
+
+void ICInvalidateRange(const void *start, size_t length);
+
+#endif /* _RVL_CACHE_H_ */

--- a/runtime-ext/vendor/bslug_include/rvl/ipc.h
+++ b/runtime-ext/vendor/bslug_include/rvl/ipc.h
@@ -1,0 +1,105 @@
+/* rvl/ipc.h
+ *   by Alex Chadwick
+ * 
+ * Copyright (C) 2014, Alex Chadwick
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* definitions of standard symbols typically in the ogc/ipc.h header file for
+ * which the brainslug symbol information is available. */
+ 
+#ifndef _RVL_IPC_H_
+#define _RVL_IPC_H_
+
+#include <stddef.h> /* for size_t */
+
+#define IPC_MAXPATH_LEN 64
+
+typedef enum {
+    IPC_OK = 0,
+    IPC_EBUSY = -2,
+    IPC_EINVAL = -4,
+    IPC_ENOENT = -6,
+    IPC_EQUEUEFULL = -8,
+    IPC_ENOMEM = -22,
+} ios_ret_t;
+
+typedef enum {
+    IPC_OPEN_NONE = 0,
+    IPC_OPEN_READ = 1,
+    IPC_OPEN_WRITE = 2,
+    IPC_OPEN_RW = IPC_OPEN_READ + IPC_OPEN_WRITE
+} ios_mode_t;
+
+typedef void *usr_t;
+typedef int ios_fd_t;
+typedef void (*ios_open_cb_t)(ios_fd_t result, usr_t usrdata);
+typedef void (*ios_cb_t)(ios_ret_t result, usr_t usrdata);
+
+typedef struct _ioctlv {
+	void *data;
+	size_t len;
+} ioctlv;
+
+ios_fd_t IOS_Open(const char *filepath, ios_mode_t mode);
+ios_ret_t IOS_OpenAsync(
+    const char *filepath, ios_mode_t mode, ios_open_cb_t cb, usr_t usrdata);
+    
+ios_ret_t IOS_Close(ios_fd_t fd);
+ios_ret_t IOS_CloseAsync(ios_fd_t fd, ios_cb_t cb, usr_t usrdata);
+
+ios_ret_t IOS_Read(ios_fd_t fd, void *buffer, size_t length);
+ios_ret_t IOS_ReadAsync(
+    ios_fd_t fd, void *buffer, size_t length, ios_cb_t cb, usr_t usrdata);
+ios_ret_t IOS_Write(ios_fd_t fd, const void *buffer, size_t length);
+ios_ret_t IOS_WriteAsync(
+    ios_fd_t fd, const void *buffer, size_t length, ios_cb_t cb, usr_t usrdata);
+ios_ret_t IOS_Seek(ios_fd_t fd, int offset, int base);
+ios_ret_t IOS_SeekAsync(
+    ios_fd_t fd, int offset, int base, ios_cb_t cb, usr_t usrdata);
+
+ios_ret_t IOS_Ioctl(
+    ios_fd_t fd, int ioctl, const void *input, size_t input_length,
+    void *output, size_t output_length);
+ios_ret_t IOS_IoctlAsync(
+    ios_fd_t fd, int ioctl, const void *input, size_t input_length,
+    void *output, size_t output_length, ios_cb_t cb, usr_t usrdata);
+
+ios_ret_t IOS_Ioctlv(
+    ios_fd_t fd, int ioctl, int input_count, int output_count, ioctlv *argv);
+ios_ret_t IOS_IoctlvAsync(
+    ios_fd_t fd, int ioctl, int input_count, int output_count, ioctlv *argv,
+    ios_cb_t cb, usr_t usrdata);
+ios_ret_t IOS_IoctlvReboot(
+    ios_fd_t fd, int ioctl, int input_count, int output_count, ioctlv *argv);
+
+typedef int hid_t;
+
+/* space must be aligned to 32 */
+hid_t iosCreateHeap(void *space, size_t size);
+void *iosAllocAligned(hid_t hid, size_t size, size_t alignment);
+static inline void *iosAlloc(hid_t hid, size_t size);
+void iosFree(hid_t hid, void *ptr);
+
+static inline void *iosAlloc(hid_t hid, size_t size) {
+    return iosAllocAligned(hid, size, 32);
+}
+    
+#endif /* _RVL_IPC_H_ */

--- a/runtime-ext/vendor/bslug_include/stdio.h
+++ b/runtime-ext/vendor/bslug_include/stdio.h
@@ -1,0 +1,98 @@
+/* stdio.h
+ *   by Alex Chadwick
+ * 
+ * Copyright (C) 2014, Alex Chadwick
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* definitions of standard symbols in the stdio.h header file for which the
+ * brainslug symbol information is available. */
+
+#ifndef _STDIO_H_
+#define _STDIO_H_
+
+/* Functions not provided in this file:
+ *  - vfprintf
+ */
+/* Nontstandard functions provided in this file:
+ * - snprintf
+ * - vsnprintf
+ */
+ 
+#include <stdarg.h>
+ 
+#ifndef EOF
+#define	EOF	(-1)
+#endif
+#ifndef SEEK_SET
+#define	SEEK_SET	0	/* set file offset to offset */
+#endif
+#ifndef SEEK_CUR
+#define	SEEK_CUR	1	/* set file offset to current plus offset */
+#endif
+#ifndef SEEK_END
+#define	SEEK_END	2	/* set file offset to EOF plus offset */
+#endif
+
+/* the exact details of the FILE structure are all largely guesswork */
+typedef int (*device_file_read_t)(
+    int fd, void *buffer, size_t *length, void *device_ptr);
+typedef int (*device_file_write_t)(
+    int fd, const void *buffer, size_t *length, void *device_ptr);
+typedef int (*device_file_close_t)(int fd);
+
+typedef struct device_file {
+} device_file_t;
+
+typedef struct FILE {
+    int fd; /* 0x00 */
+    unsigned char unknown04[0x1c - 0x04]; /* 0x04 */
+    void *buffer; /* 0x1c */
+    size_t buffer_size; /* 0x20 */
+    void *buffer_end; /* 0x24 */
+    size_t io_size; /* 0x28 */
+    unsigned char unknown2c[0x3c - 0x2c]; /* 0x2c */
+    device_file_read_t read_fn; /* 0x3c */
+    device_file_write_t write_fn; /* 0x40 */
+    device_file_close_t close_fn; /* 0x44 */
+    void *device_ptr; /* 0x48 */
+    struct FILE *next_file; /* 0x4c */
+} FILE;
+
+#ifdef __GNUC__
+#ifndef __ATTRIBUTE_PRINTF
+#define __ATTRIBUTE_PRINTF(str, args) \
+    __attribute__ ((format (printf, str, args)))
+#endif
+#endif
+
+size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
+
+int fprintf(FILE *stream, const char *format, ...) __ATTRIBUTE_PRINTF(2, 3);
+int printf(const char *format, ...) __ATTRIBUTE_PRINTF(1, 2);
+int sprintf(char *str, const char *format, ...) __ATTRIBUTE_PRINTF(2, 3);
+int snprintf(char *str, size_t len, const char *format, ...)
+    __ATTRIBUTE_PRINTF(3, 4);
+    
+int vprintf(const char *format, va_list arg);
+int vsprintf(char *str, const char *format, va_list arg);
+int vsnprintf(char *str, size_t len, const char *format, va_list arg);
+
+#endif /* _STDIO_H_ */

--- a/runtime-ext/vendor/bslug_include/stdlib.h
+++ b/runtime-ext/vendor/bslug_include/stdlib.h
@@ -1,6 +1,6 @@
-/* main.c
+/* stdlib.h
  *   by Alex Chadwick
- *
+ * 
  * Copyright (C) 2014, Alex Chadwick
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,4 +22,12 @@
  * SOFTWARE.
  */
 
-#include <io/libsd.h>
+/* definitions of standard symbols in the stdlib.h header file for which the
+ * brainslug symbol information is available. */
+
+#ifndef _STDLIB_H_
+#define _STDLIB_H_
+
+#define MB_CUR_MAX 6
+
+#endif /* _STDLIB_H_ */

--- a/runtime-ext/vendor/bslug_include/string.h
+++ b/runtime-ext/vendor/bslug_include/string.h
@@ -1,0 +1,73 @@
+/* string.h
+ *   by Alex Chadwick
+ * 
+ * Copyright (C) 2014, Alex Chadwick
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* definitions of standard symbols in the string.h header file for which the
+ * brainslug symbol information is available. */
+
+#ifndef _STRING_H_
+#define _STRING_H_
+
+/* Functions not provided in this file:
+ *  - strncat
+ *  - strcoll
+ *  - strcspn
+ *  - strerror
+ */
+/* Nontstandard functions provided in this file:
+ * - memrchr
+ */
+
+#include <stddef.h>
+
+#ifndef NULL
+#define NULL 0
+#endif
+
+void *memcpy(void *dst, const void *src, size_t num);
+void *memchr(const void *ptr, int value, size_t num); 
+void *memrchr(const void *ptr, int value, size_t num); 
+int memcmp(const void *ptr1, const void *ptr2, size_t num);
+void *memmove(void *dst, const void *src, size_t num);
+void *memset(void *ptr, int value, size_t num);
+char *strcpy(char *dst, const char *src);
+char *strncpy(char *dst, const char *src, size_t maxlen);
+char *strcat(char *dst, const char *src);
+char *strchr(const char *str, int character);
+int strcmp (const char *str1, const char *str2);
+size_t strlen(const char *s);
+int strncmp (const char *str1, const char *str2, size_t maxlen);
+size_t strnlen(const char *s, size_t maxlen);
+
+static inline char *strrchr(const char *str, int character) {
+    return memrchr(str, character, strlen(str) + 1);
+}
+static inline char *strpbrk(const char *str, const char *set) {
+    char *result = (char *)str;
+    for (; result[0] != '\0'; result++)
+        if (strchr(set, result[0]) != NULL)
+            return result;
+    return NULL;
+}
+
+#endif /* _STRING_H_ */

--- a/runtime-ext/vendor/bslug_include/sys/stat.h
+++ b/runtime-ext/vendor/bslug_include/sys/stat.h
@@ -1,0 +1,97 @@
+/* sys/stat.h
+ *   by Alex Chadwick
+ * 
+ * Copyright (C) 2014, Alex Chadwick
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* definitions of standard symbols in the sys/stat.h header file. */
+
+#ifndef _SYS_STAT_H_
+#define _SYS_STAT_H_
+
+#include <sys/types.h>
+
+struct stat {
+  dev_t		st_dev;
+  ino_t		st_ino;
+  mode_t	st_mode;
+  nlink_t	st_nlink;
+  uid_t		st_uid;
+  gid_t		st_gid;
+  dev_t		st_rdev;
+  off_t		st_size;
+  time_t	st_atime;
+  long		st_spare1;
+  time_t	st_mtime;
+  long		st_spare2;
+  time_t	st_ctime;
+  long		st_spare3;
+  long		st_blksize;
+  long		st_blocks;
+  long		st_spare4[2];
+};
+
+#define	_IFMT		0170000	/* type of file */
+#define		_IFDIR	0040000	/* directory */
+#define		_IFCHR	0020000	/* character special */
+#define		_IFBLK	0060000	/* block special */
+#define		_IFREG	0100000	/* regular */
+#define		_IFLNK	0120000	/* symbolic link */
+#define		_IFSOCK	0140000	/* socket */
+#define		_IFIFO	0010000	/* fifo */
+
+#define 	S_BLKSIZE  1024 /* size of a block */
+
+#define	S_ISUID		0004000	/* set user id on execution */
+#define	S_ISGID		0002000	/* set group id on execution */
+#define	S_ISVTX		0001000	/* save swapped text even after use */
+
+#define	S_IFMT		_IFMT
+#define	S_IFDIR		_IFDIR
+#define	S_IFCHR		_IFCHR
+#define	S_IFBLK		_IFBLK
+#define	S_IFREG		_IFREG
+#define	S_IFLNK		_IFLNK
+#define	S_IFSOCK	_IFSOCK
+#define	S_IFIFO		_IFIFO
+
+#define	S_IRWXU 	(S_IRUSR | S_IWUSR | S_IXUSR)
+#define		S_IRUSR	0000400	/* read permission, owner */
+#define		S_IWUSR	0000200	/* write permission, owner */
+#define		S_IXUSR 0000100/* execute/search permission, owner */
+#define	S_IRWXG		(S_IRGRP | S_IWGRP | S_IXGRP)
+#define		S_IRGRP	0000040	/* read permission, group */
+#define		S_IWGRP	0000020	/* write permission, grougroup */
+#define		S_IXGRP 0000010/* execute/search permission, group */
+#define	S_IRWXO		(S_IROTH | S_IWOTH | S_IXOTH)
+#define		S_IROTH	0000004	/* read permission, other */
+#define		S_IWOTH	0000002	/* write permission, other */
+#define		S_IXOTH 0000001/* execute/search permission, other */
+
+#define	S_ISBLK(m)	(((m)&_IFMT) == _IFBLK)
+#define	S_ISCHR(m)	(((m)&_IFMT) == _IFCHR)
+#define	S_ISDIR(m)	(((m)&_IFMT) == _IFDIR)
+#define	S_ISFIFO(m)	(((m)&_IFMT) == _IFIFO)
+#define	S_ISREG(m)	(((m)&_IFMT) == _IFREG)
+#define	S_ISLNK(m)	(((m)&_IFMT) == _IFLNK)
+#define	S_ISSOCK(m)	(((m)&_IFMT) == _IFSOCK)
+
+#endif /* _SYS_STAT_H_ */

--- a/runtime-ext/vendor/bslug_include/sys/statvfs.h
+++ b/runtime-ext/vendor/bslug_include/sys/statvfs.h
@@ -1,6 +1,6 @@
-/* main.c
+/* sys/statvfs.h
  *   by Alex Chadwick
- *
+ * 
  * Copyright (C) 2014, Alex Chadwick
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,4 +22,28 @@
  * SOFTWARE.
  */
 
-#include <io/libsd.h>
+/* definitions of standard symbols in the sys/statvfs.h header file. */
+
+#ifndef _SYS_STATVFS_H_
+#define _SYS_STATVFS_H_
+
+#include <sys/types.h>
+
+struct statvfs {
+	unsigned long f_bsize;
+	unsigned long f_frsize;
+	fsblkcnt_t f_blocks;
+	fsblkcnt_t f_bfree;
+	fsblkcnt_t f_bavail;
+	fsfilcnt_t f_files;
+	fsfilcnt_t f_ffree;
+	fsfilcnt_t f_favail;
+	unsigned long f_fsid;
+	unsigned long f_flag;
+	unsigned long f_namemax;
+};
+
+#define ST_RDONLY 0x0001
+#define ST_NOSUID 0x0002
+
+#endif /* _SYS_STATVFS_H_ */

--- a/runtime-ext/vendor/bslug_include/sys/types.h
+++ b/runtime-ext/vendor/bslug_include/sys/types.h
@@ -1,6 +1,6 @@
-/* main.c
+/* sys/types.h
  *   by Alex Chadwick
- *
+ * 
  * Copyright (C) 2014, Alex Chadwick
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,4 +22,23 @@
  * SOFTWARE.
  */
 
-#include <io/libsd.h>
+/* definitions of standard symbols in the sys/types.h header file. */
+
+#ifndef _SYS_TYPES_H_
+#define _SYS_TYPES_H_
+
+#include <stdint.h>
+
+typedef	unsigned int    ino_t;
+typedef long            off_t;
+typedef short           dev_t;
+typedef unsigned short  uid_t;
+typedef unsigned short  gid_t;
+typedef int             ssize_t;
+typedef unsigned int    mode_t;
+typedef unsigned short  nlink_t;
+typedef uint64_t        time_t;
+typedef uint32_t        fsblkcnt_t;
+typedef uint32_t        fsfilcnt_t;
+
+#endif /* _SYS_TYPES_H_ */

--- a/runtime-ext/vendor/bslug_include/time.h
+++ b/runtime-ext/vendor/bslug_include/time.h
@@ -1,0 +1,147 @@
+/* time.h
+ *   by Alex Chadwick
+ * 
+ * Copyright (C) 2014, Alex Chadwick
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* definitions of standard symbols in the time.h. These methods are provide in
+ * the libc module. */
+
+#ifndef _TIME_H_
+#define _TIME_H_
+
+/* Functions not provided in this file:
+ *  - asctime
+ *  - ctime
+ *  - strftime
+ */
+/* Nontstandard functions provided in this file:
+ * - localtime_r
+ * - gmtime_r
+ *
+ * The implementation of gmtime is to return localtime in all cases.
+ */
+
+#include <rvl/OSTime.h>
+#include <stddef.h>
+#include <sys/types.h>
+
+#define CLOCKS_PER_SEC 1000
+
+typedef unsigned long clock_t;
+
+struct tm {
+  int	tm_sec;
+  int	tm_min;
+  int	tm_hour;
+  int	tm_mday;
+  int	tm_mon;
+  int	tm_year;
+  int	tm_wday;
+  int	tm_yday;
+  int	tm_isdst;
+};
+
+static inline clock_t clock(void) {
+    return ticks_to_millisecs(OSGetTime());
+}
+static inline double difftime(time_t end, time_t beginning) {
+    return ticks_to_secs((double)(end - beginning));
+}
+/* naughtily, I ignore daylight savings! */
+static inline time_t mktime(struct tm *tim_p) {
+    /* this needs verifying! */
+#define _SEC_IN_MINUTE 60L
+#define _SEC_IN_HOUR 3600L
+#define _SEC_IN_DAY 86400L
+
+static const int _DAYS_BEFORE_MONTH[12] =
+{0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
+
+#define _ISLEAP(y) (((y) % 4) == 0 && (((y) % 100) != 0 || (((y)+1900) % 400) == 0))
+#define _DAYS_IN_YEAR(year) (_ISLEAP(year) ? 366 : 365)
+
+    time_t tim = 0;
+    long days = 0;
+    int year;
+    
+    /* compute hours, minutes, seconds */
+    tim += tim_p->tm_sec + (tim_p->tm_min * _SEC_IN_MINUTE) +
+        (tim_p->tm_hour * _SEC_IN_HOUR);
+    /* compute days in year */
+    days += tim_p->tm_mday - 1;
+    days += _DAYS_BEFORE_MONTH[tim_p->tm_mon];
+    if (tim_p->tm_mon > 1 && _DAYS_IN_YEAR (tim_p->tm_year) == 366)
+        days++;
+        
+    if ((year = tim_p->tm_year) > 100) {
+        for (year = 100; year < tim_p->tm_year; year++)
+            days += _DAYS_IN_YEAR (year);
+    } else if (year < 100) {
+        for (year = 99; year > tim_p->tm_year; year--)
+            days -= _DAYS_IN_YEAR (year);
+        days -= _DAYS_IN_YEAR (year);
+    }
+    tim += (days * _SEC_IN_DAY);
+    
+    return secs_to_ticks(tim);
+}
+static inline time_t time(time_t *timer) {
+    time_t clk = OSGetTime();
+    if (timer != NULL) *timer = clk;
+    return clk;
+}
+static inline struct tm *localtime(const time_t *timer) {
+    static struct tm date;
+    OSCalendarTime_t ct;
+    
+    OSTicksToCalendarTime(*timer, &ct);
+    date.tm_sec = ct.tm_sec;
+    date.tm_min = ct.tm_min;
+    date.tm_hour = ct.tm_hour;
+    date.tm_mday = ct.tm_mday;
+    date.tm_mon = ct.tm_mon;
+    date.tm_year = ct.tm_year;
+    date.tm_wday = ct.tm_wday;
+    date.tm_yday = ct.tm_yday;
+    date.tm_isdst = 0;
+    return &date;
+}
+#define gmtime localtime
+
+static inline struct tm *localtime_r(const time_t *timer, struct tm *date) {
+    OSCalendarTime_t ct;
+    
+    OSTicksToCalendarTime(*timer, &ct);
+    date->tm_sec = ct.tm_sec;
+    date->tm_min = ct.tm_min;
+    date->tm_hour = ct.tm_hour;
+    date->tm_mday = ct.tm_mday;
+    date->tm_mon = ct.tm_mon;
+    date->tm_year = ct.tm_year;
+    date->tm_wday = ct.tm_wday;
+    date->tm_yday = ct.tm_yday;
+    date->tm_isdst = 0;
+    return date;
+}
+#define gmtime_r localtime_r
+
+#endif /* _TIME_H_ */

--- a/runtime-ext/vendor/bslug_include/wchar.h
+++ b/runtime-ext/vendor/bslug_include/wchar.h
@@ -1,0 +1,208 @@
+/* wchar.h
+ *   by Alex Chadwick
+ * 
+ * Copyright (C) 2014, Alex Chadwick
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* definitions of standard symbols in the wchar.h. These methods are provided in
+ * the libc module. */
+
+#ifndef _WCHAR_H_
+#define _WCHAR_H_
+
+#define __need_wint_t
+#include <stddef.h>
+#include <stdint.h>
+#include <rvl/OSUtf.h>
+
+#ifndef NULL
+#define NULL 0
+#endif
+
+#ifndef WEOF
+#define WEOF ((wint_t)-1)
+#endif
+
+#ifndef WCHAR_MIN
+#define WCHAR_MIN 0
+#endif
+
+#ifndef WCHAR_MAX
+#define WCHAR_MAX 0xffffu
+#endif
+
+/* Conversion state information.  */
+typedef struct {
+  int __count;
+  union {
+    wint_t __wch;
+    char __wchb[4];
+  } __value;		/* Value so far.  */
+} mbstate_t;
+
+static inline size_t mbrtowc(
+    wchar_t *pwc, const char *pmb, size_t max, mbstate_t *ps);
+static inline size_t mbsrtowcs(
+    wchar_t *dest, const char **src, size_t max, mbstate_t *ps);
+static inline size_t wcrtomb(char *pmb, wchar_t wc, mbstate_t *ps);
+static inline int wctob(wint_t wc);
+
+static inline size_t mbrtowc(
+        wchar_t *pwc, const char *pmb, size_t max, mbstate_t *ps) {
+    static mbstate_t internal_state;
+    int wchar;
+    size_t bytes, i;
+    char *res;
+    
+    if (ps == NULL)
+        ps = &internal_state;
+    if (pmb == NULL) {
+        /* finish conversion. */
+        if (ps->__count == 0)
+            return (size_t)0;
+        else
+            return (size_t)-1;
+    }
+    /* We should not have a full (or overfull) buffer. */
+    if (ps->__count >= sizeof(ps->__value.__wchb))
+        return (size_t)-1;
+    /* we need some bytes! */
+    if (max == 0)
+        return (size_t)-2;
+    
+    /* copy bytes to buffer. */
+    for (i = 0;
+         i < max && ps->__count < sizeof(ps->__value.__wchb);
+         i++, ps->__count++) {
+        ps->__value.__wchb[ps->__count] = pmb[i];
+    }
+    /* zero out remaining buffer space. */
+    for (i = ps->__count; i < sizeof(ps->__value.__wchb); i++) {
+        ps->__value.__wchb[i] = 0;
+    }
+    
+    res = OSUTF8to32(ps->__value.__wchb, &wchar);
+    
+    if (res == NULL) {
+        /* conversion error. */
+        if (ps->__count < sizeof(ps->__value.__wchb)) {
+            /* probably because we don't have enough chars. */
+            return (size_t)-2;
+        }
+        return (size_t)-1;
+    }
+    
+    bytes = res - ps->__value.__wchb;
+    
+    if (bytes > sizeof(ps->__value.__wchb)) {
+        /* this should be impossible. Their implementation of OSUTF8to32. Never
+         * reads beyond 4 bytes. */
+        return (size_t)-1;
+    }
+    if (bytes > ps->__count) {
+        /* this should be impossible. 0 is never valid, so our zero padding
+         * should cause a conversion error. */
+        return (size_t)-1;
+    }
+    
+    /* reset shift state. */
+    ps->__count = 0;
+    
+    if (pwc)
+        *pwc = (wchar_t)wchar;
+    return bytes;
+}
+static inline size_t mbsrtowcs(
+        wchar_t *dest, const char **src, size_t max, mbstate_t *ps) {
+    size_t i;
+    const char *cur;
+    
+    cur = *src;
+    for (i = 0; i < max; i++) {
+        int utf32;
+        const char *end;
+        
+        end = OSUTF8to32(cur, &utf32);
+        if (end == NULL) {
+            *src = cur;
+            return (size_t)-1;
+        }
+        if (cur == end) {
+            *src = NULL;
+            if (dest)
+                *dest = L'\0';
+            return i;
+        }
+        
+        if (dest) {
+            *dest = (wchar_t)utf32;
+            dest++;
+        }
+        cur = end;
+    }
+    
+    *src = cur;
+    return i;
+}
+static inline size_t wcrtomb(char *pmb, wchar_t wc, mbstate_t *ps) {
+    size_t bytes;
+
+    if ((wc  >= 0x0000D800 && wc <= 0x0000DFFF)
+        || wc > 0x00200000 || wc == 0x0000FFFF || wc == 0x0000FFFE)
+        return (size_t)0;
+
+    if (wc < 0x80)
+        bytes = 1;
+    else if (wc < 0x800)
+        bytes = 2;
+    else if (wc < 0x10000)
+        bytes = 3;
+    else if (wc < 0x200000)
+        bytes = 4;
+
+    switch (bytes) {
+    case 1:
+        *pmb = (unsigned char)wc;
+        break;
+    case 2:
+        *pmb++ = (unsigned char)((wc >> 6) | 0x000000C0);
+        *pmb++ = (unsigned char)((wc & 0x0000003F) | 0x00000080);
+        break;
+    case 3:
+        *pmb++ = (unsigned char)((wc >> 12) | 0x000000E0);
+        *pmb++ = (unsigned char)(((wc >> 6) & 0x0000003F) | 0x00000080);
+        *pmb++ = (unsigned char)((wc        & 0x0000003F) | 0x00000080);
+        break;
+    case 4:
+        *pmb++ = (unsigned char)((wc >> 18)  | 0x000000F0);
+        *pmb++ = (unsigned char)(((wc >> 12) & 0x0000003F) | 0x00000080);
+        *pmb++ = (unsigned char)(((wc >> 6)  & 0x0000003F) | 0x00000080);
+        *pmb++ = (unsigned char)((wc         & 0x0000003F) | 0x00000080);
+        break;
+    }
+
+    return bytes;
+}
+static inline int wctob(wint_t wc) {
+    return OSUTF32toANSI(wc);
+}
+
+#endif /* _WCHAR_H_ */

--- a/runtime-ext/vendor/libfat-sd/main.c
+++ b/runtime-ext/vendor/libfat-sd/main.c
@@ -22,7 +22,6 @@
  * SOFTWARE.
  */
 
-#include <bslug.h>
 #include <errno.h>
 #include <io/fat-sd.h>
 #include <io/libsd.h>

--- a/runtime-ext/vendor/libfat/module.c
+++ b/runtime-ext/vendor/libfat/module.c
@@ -22,5 +22,4 @@
  * SOFTWARE.
  */
 
-#include <bslug.h>
 #include <io/fat.h>

--- a/source/loader/riivo_patch_loader.c
+++ b/source/loader/riivo_patch_loader.c
@@ -121,6 +121,7 @@ struct rrc_result rrc_riivo_patch_loader_parse(struct rrc_settingsfile *settings
     *mem1 -= sizeof(struct rrc_riivo_disc_replacement) * MAX_FILE_PATCHES;
     *mem1 -= sizeof(struct rrc_riivo_disc);
     struct rrc_riivo_disc *riivo_disc = (void *)*mem1;
+    riivo_disc->count = 0;
     // Reserve space for memory patches. Note: they don't actually need to be reserved in MEM1,
     // because it's only shortly needed in patch.c and never again at runtime.
     *mem1 -= sizeof(struct rrc_riivo_memory_patch) * MAX_MEMORY_PATCHES;


### PR DESCRIPTION
Currently you need to "install" brainslug into your dkp toolchain since we need some of its header files.
However, this is a bit annoying, and since we already have some (modified) brainslug code checked into the repo anyway (for SD handling at game runtime), we might as well vendor the last header files in so we can get rid of that install step.

Also changes the readme to mention ppc-portlibs which is needed for ppc-mxml, and changes the install script to create a proper unique temp dir that's deleted at the end of the script