### PR TITLE
Move version parsing to a struct

### DIFF
--- a/source/console.c
+++ b/source/console.c
@@ -25,11 +25,12 @@
 #include "update/update.h"
 #include "console.h"
 #include "util.h"
+#include "version.h"
 
 /* 100 = 100% */
 int rrc_con_progress_percent = 0;
 char *rrc_con_current_action;
-int cached_version = -1;
+struct rrc_version cached_version = {-1, -1, -1};
 
 int rrc_con_get_cols()
 {
@@ -88,14 +89,14 @@ int rrc_con_centered_text_start_column(char *text)
 
 void rrc_con_display_version()
 {
-    if (cached_version == -1)
+    if (cached_version.major == -1)
     {
         struct rrc_result version_result = rrc_update_get_current_version(&cached_version);
         rrc_result_error_check_error_fatal(version_result);
     }
 
     char vertext[32];
-    snprintf(vertext, 32, "Version: %i.%i.%i", cached_version / 100, (cached_version / 10) % 10, cached_version % 10);
+    snprintf(vertext, 32, "Version: %i.%i.%i", cached_version.major, cached_version.minor, cached_version.patch);
     rrc_con_cursor_seek_to(rrc_con_get_rows() - 2, rrc_con_get_cols() - strlen(vertext));
     printf("%s", vertext);
 }

--- a/source/loader/riivo_patch_loader.c
+++ b/source/loader/riivo_patch_loader.c
@@ -280,8 +280,6 @@ struct rrc_result rrc_riivo_patch_loader_parse(struct rrc_settingsfile *settings
             char *disc_path_m1 = bump_alloc_string(mem1, disc_path_mxml);
             char *external_path_m1 = bump_alloc_string(mem1, external_path_mxml);
 
-            rrc_dbg_printf("File: disc='%s', external='%s'\n", disc_path_mxml, external_path_mxml);
-
             struct rrc_riivo_disc_replacement *patch_dist = &riivo_disc->replacements[riivo_disc->count];
             patch_dist->disc = disc_path_m1;
             patch_dist->external = external_path_m1;

--- a/source/settings.c
+++ b/source/settings.c
@@ -456,7 +456,10 @@ enum rrc_settings_result rrc_settings_display(void *xfb, struct rrc_settingsfile
                         }
                         else if (updated)
                         {
-                            snprintf(status_message, sizeof(status_message), RRC_CON_ANSI_FG_BRIGHT_GREEN "%d updates installed." RRC_CON_ANSI_CLR, update_count);
+                            snprintf(status_message, sizeof(status_message), "%d updates were installed.", update_count);
+                            char *lines[] = { status_message, "", "The channel will now exit to apply the updates."};
+                            rrc_prompt_1_option(xfb, lines, 3, "OK");
+                            goto exit;
                         }
 
                         status_message_row = 3;

--- a/source/update/update.c
+++ b/source/update/update.c
@@ -34,10 +34,11 @@
 #include "../time.h"
 #include "../prompt.h"
 #include "../shutdown.h"
+#include "../version.h"
 
 #define _RRC_UPDATE_ZIP_NAME "update.zip"
 
-struct rrc_result rrc_update_get_current_version(int *version)
+struct rrc_result rrc_update_get_current_version(struct rrc_version *version)
 {
     FILE *file = fopen(RRC_VERSIONFILE, "r");
     if (file == NULL)
@@ -68,18 +69,17 @@ struct rrc_result rrc_update_get_current_version(int *version)
     /* add null termination */
     verstring[sz] = '\0';
 
-    return rrc_versionsfile_parse_verstring(verstring, version);
+    return rrc_version_from_string(verstring, version);
 }
 
-struct rrc_result rrc_update_set_current_version(int version)
+struct rrc_result rrc_update_set_current_version(struct rrc_version *version)
 {
-    int p1 = version / 100;
-    version %= 100;
-    int p2 = version / 10;
-    version %= 10;
+    int p1 = version->major;
+    int p2 = version->minor;
+    int p3 = version->patch;
 
     char out[32];
-    int written = snprintf(out, sizeof(out), "%d.%d.%d", p1, p2, version);
+    int written = snprintf(out, sizeof(out), "%d.%d.%d", p1, p2, p3);
     RRC_ASSERT(written < sizeof(out), "version string too long");
     FILE *file = fopen(RRC_VERSIONFILE, "w");
     if (file == NULL)
@@ -446,7 +446,7 @@ struct rrc_result rrc_update_do_updates_with_state(struct rrc_update_state *stat
         for (int i = 0; i < state->num_deleted_files; i++)
         {
             struct rrc_versionsfile_deleted_file *file = &state->deleted_files[i];
-            if (file->version == state->update_versions[state->current_update_num])
+            if (rrc_version_equals(&file->version, &state->update_versions[state->current_update_num]))
             {
                 char out[100];
                 snprintf(out, 100, "Removing deleted file %s\n", file->path);
@@ -460,7 +460,7 @@ struct rrc_result rrc_update_do_updates_with_state(struct rrc_update_state *stat
         }
 
         // Update the version.txt file
-        TRY(rrc_update_set_current_version(state->update_versions[state->current_update_num]));
+        TRY(rrc_update_set_current_version(&state->update_versions[state->current_update_num]));
 
         state->current_update_num++;
     }
@@ -485,7 +485,8 @@ struct rrc_result rrc_update_do_updates(void *xfb, int *count, bool *updates_ins
     int num_deleted_files = 0;
     struct rrc_versionsfile_deleted_file *deleted_files = NULL;
     char **zip_urls = NULL;
-    int *update_versions = NULL;
+    // Packed array of version (non-pointer)
+    struct rrc_version *update_versions = NULL;
     rrc_con_update("Get Versions", 10);
     res = rrc_versionsfile_get_versionsfile(&versionsfile);
     if (res < 0)
@@ -493,14 +494,14 @@ struct rrc_result rrc_update_do_updates(void *xfb, int *count, bool *updates_ins
         return rrc_result_create_error_curl(-res, "Failed to get version information.");
     }
 
-    int current;
+    struct rrc_version current = {-1, -1, -1};
     TRY(rrc_update_get_current_version(&current));
 
-    RRC_ASSERT(current >= 0, "failed to read current version file");
-    rrc_dbg_printf("Current version: %i\n", current);
+    RRC_ASSERT(current.major >= 0, "failed to read current version file");
+    rrc_dbg_printf("Current version: %i.%i.%i\n", current.major, current.minor, current.patch);
 
     rrc_con_update("Get Download URLs", 20);
-    TRY(rrc_versionsfile_get_necessary_urls_and_versions(versionsfile, current, count, &zip_urls, &update_versions));
+    TRY(rrc_versionsfile_get_necessary_urls_and_versions(versionsfile, &current, count, &zip_urls, &update_versions));
 
     if (*count > 0)
     {
@@ -520,7 +521,7 @@ struct rrc_result rrc_update_do_updates(void *xfb, int *count, bool *updates_ins
         RRC_FATAL("couldnt get files to remove! res: %i\n", res);
     }
 
-    TRY(rrc_versionsfile_parse_deleted_files(deleted_versionsfile, current, &deleted_files, &num_deleted_files));
+    TRY(rrc_versionsfile_parse_deleted_files(deleted_versionsfile, &current, &deleted_files, &num_deleted_files));
 
     rrc_dbg_printf("%i updates\n", *count);
     struct rrc_update_state state =

--- a/source/update/update.h
+++ b/source/update/update.h
@@ -21,6 +21,7 @@
 
 #include <curl/curl.h>
 #include "../result.h"
+#include "../version.h"
 
 #define RRC_UPDATE_LARGE_THRESHOLD (long)(1000 * 1000 * 100) /* 100MB */
 #define RRC_VERSIONFILE "RetroRewind6/version.txt"
@@ -37,9 +38,9 @@ struct rrc_update_state
     /* All URLs for updates, in order. Length = num_updates */
     char **update_urls;
     /* Version of each update. Has the same length as `update_urls` and each index into update_urls is also valid for update_versions */
-    int *update_versions;
+    struct rrc_version *update_versions;
     /* The current version. */
-    int current_version;
+    struct rrc_version current_version;
     /* Amount of files to delete. */
     int num_deleted_files;
     /* Files to delete. */
@@ -51,13 +52,13 @@ struct rrc_update_state
     E.g., 4.2.0 = 420
     SD driver must be loaded for this to work.
 */
-struct rrc_result rrc_update_get_current_version(int *version);
+struct rrc_result rrc_update_get_current_version(struct rrc_version *version);
 
 /*
     Writes the specified version int into version.txt.
     SD driver must be loaded for this to work.
 */
-struct rrc_result rrc_update_set_current_version(int version);
+struct rrc_result rrc_update_set_current_version(struct rrc_version *version);
 
 /*
     Downloads a Retro Rewind ZIP. Uses the console to display progress.

--- a/source/update/versionsfile.c
+++ b/source/update/versionsfile.c
@@ -31,56 +31,6 @@
 // max array size
 #define _RRC_SPLIT_LIM 4096
 
-struct rrc_result rrc_versionsfile_parse_verstring(char *verstring, int *version)
-{
-    /* major, minor, revision */
-    int parts[3] = {0, 0, 0};
-    int current = 0, started_at = 0;
-    int len = strlen(verstring);
-    for (int i = 0; i < len + 1; i++)
-    {
-        /* read until . or EOF, then extract that section */
-        if (verstring[i] == '.' || verstring[i] == '\0')
-        {
-            int sect_len = i - started_at;
-            if (sect_len == 0)
-            {
-                /* ??? */
-                return rrc_result_create_error_corrupted_versionfile("Invalid format");
-            }
-
-            /* read this section */
-            char section[sect_len + 1];
-            int idx = 0;
-            for (int j = started_at; j < started_at + sect_len; j++)
-            {
-                section[idx] = verstring[j];
-                idx++;
-            }
-            section[sect_len] = '\0';
-
-            int section_l = strtol(section, NULL, 10);
-            parts[current] = section_l;
-            current++;
-            if (current > 2)
-            {
-                /* we read the rev now */
-                break;
-            }
-
-            started_at = i + 1;
-        }
-    }
-
-    int final = 0;
-    final += (parts[0] * 100);
-    final += (parts[1] * 10);
-    final += parts[2];
-
-    *version = final;
-    return rrc_result_success;
-}
-
 struct ptr_len_pair
 {
     int len;
@@ -266,7 +216,7 @@ void rrc_versionsfile_free_split(char **array, int count)
     free(array);
 }
 
-struct rrc_result rrc_versionsfile_get_necessary_urls_and_versions(char *versionsfile, int current_version, int *uamt, char ***urls, int **versions)
+struct rrc_result rrc_versionsfile_get_necessary_urls_and_versions(char *versionsfile, struct rrc_version *current_version, int *uamt, char ***urls, struct rrc_version **versions)
 {
     /*
         We need to read the file line-wise and also space-wise.
@@ -280,7 +230,7 @@ struct rrc_result rrc_versionsfile_get_necessary_urls_and_versions(char *version
         we parse the url associated with it and add it to the list of updates.
     */
     *urls = malloc(_RRC_SPLIT_LIM);
-    *versions = malloc(_RRC_SPLIT_LIM);
+    *versions = malloc(_RRC_SPLIT_LIM * sizeof(struct rrc_version));
 
     char **lines;
     int count;
@@ -313,8 +263,8 @@ struct rrc_result rrc_versionsfile_get_necessary_urls_and_versions(char *version
             return rrc_result_create_error_corrupted_versionfile("Failed to split versionfile");
         }
 
-        int verint;
-        struct rrc_result verstring_res = rrc_versionsfile_parse_verstring(parts[0], &verint);
+        struct rrc_version verint;
+        struct rrc_result verstring_res = rrc_version_from_string(parts[0], &verint);
 
         if (rrc_result_is_error(verstring_res))
         {
@@ -322,7 +272,8 @@ struct rrc_result rrc_versionsfile_get_necessary_urls_and_versions(char *version
             return verstring_res;
         }
 
-        if (verint > current_version)
+        // if the version is newer than our current version, we need to update to it
+        if (rrc_version_is_older(current_version, &verint))
         {
             (*versions)[update_idx] = verint;
             (*urls)[update_idx] = parts[1];
@@ -348,7 +299,7 @@ struct rrc_result rrc_versionsfile_get_necessary_urls_and_versions(char *version
     return rrc_result_success;
 }
 
-struct rrc_result rrc_versionsfile_parse_deleted_files(char *input, int current_version, struct rrc_versionsfile_deleted_file **output, int *amt)
+struct rrc_result rrc_versionsfile_parse_deleted_files(char *input, struct rrc_version *current_version, struct rrc_versionsfile_deleted_file **output, int *amt)
 {
     *output = malloc(sizeof(struct rrc_versionsfile_deleted_file) * _RRC_SPLIT_LIM);
     int output_idx = 0;
@@ -376,8 +327,8 @@ struct rrc_result rrc_versionsfile_parse_deleted_files(char *input, int current_
             return rrc_result_create_error_corrupted_versionfile("Failed to split deleted versionfile");
         }
 
-        int verint;
-        struct rrc_result verstring_res = rrc_versionsfile_parse_verstring(parts[0], &verint);
+        struct rrc_version verint;
+        struct rrc_result verstring_res = rrc_version_from_string(parts[0], &verint);
 
         if (rrc_result_is_error(verstring_res))
         {
@@ -385,7 +336,7 @@ struct rrc_result rrc_versionsfile_parse_deleted_files(char *input, int current_
             return verstring_res;
         }
 
-        if (verint > current_version)
+        if (rrc_version_is_older(&verint, current_version))
         {
             struct rrc_versionsfile_deleted_file file = {
                 .version = verint,

--- a/source/update/versionsfile.c
+++ b/source/update/versionsfile.c
@@ -336,7 +336,7 @@ struct rrc_result rrc_versionsfile_parse_deleted_files(char *input, struct rrc_v
             return verstring_res;
         }
 
-        if (rrc_version_is_older(&verint, current_version))
+        if (rrc_version_is_older(current_version, &verint))
         {
             struct rrc_versionsfile_deleted_file file = {
                 .version = verint,

--- a/source/update/versionsfile.h
+++ b/source/update/versionsfile.h
@@ -20,10 +20,11 @@
 #define RRC_VERSIONSFILE_H
 
 #include "../result.h"
+#include "../version.h"
 
 struct rrc_versionsfile_deleted_file
 {
-    int version;
+    struct rrc_version version;
     char *path;
 };
 
@@ -40,12 +41,6 @@ struct rrc_versionsfile_deleted_file
 */
 int rrc_versionsfile_split_by(char *in, char by, char ***out, int *amt);
 void rrc_versionsfile_free_split(char **array, int count);
-
-/*
-    Returns an int specifying version information from a verstring.
-    E.g., 4.2.0 = 420
-*/
-struct rrc_result rrc_versionsfile_parse_verstring(char *verstring, int *version);
 
 /*
     Get version information from Retro Rewind servers.
@@ -65,8 +60,8 @@ int rrc_versionsfile_get_removed_files(char **result);
     Get an array of all URLs we need to download, where the first index needs downloading first.
     On success, return code is 0 and `result' is populated with an array of strings and `count' is set to the amount of entries.
 */
-struct rrc_result rrc_versionsfile_get_necessary_urls_and_versions(char *versionsfile, int current_version, int *count, char ***result, int **versions);
+struct rrc_result rrc_versionsfile_get_necessary_urls_and_versions(char *versionsfile, struct rrc_version *current_version, int *uamt, char ***urls, struct rrc_version **versions);
 
-struct rrc_result rrc_versionsfile_parse_deleted_files(char *input, int current_version, struct rrc_versionsfile_deleted_file **output, int *amt);
+struct rrc_result rrc_versionsfile_parse_deleted_files(char *input, struct rrc_version *current_version, struct rrc_versionsfile_deleted_file **output, int *amt);
 
 #endif

--- a/source/version.c
+++ b/source/version.c
@@ -1,0 +1,95 @@
+/*
+    version.c - version structure and related functions
+
+    Copyright (C) 2025  Retro Rewind Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "version.h"
+#include <string.h>
+#include <stdlib.h>
+
+bool rrc_version_is_older(const struct rrc_version *a, const struct rrc_version *b)
+{
+    if (a->major < b->major)
+        return true;
+    else if (a->major > b->major)
+        return false;
+
+    if (a->minor < b->minor)
+        return true;
+    else if (a->minor > b->minor)
+        return false;
+
+    if (a->patch < b->patch)
+        return true;
+    else
+        return false;
+}
+
+struct rrc_result rrc_version_from_string(const char *version_str, struct rrc_version *out_version)
+{
+    // FIXME: Support 4-part version strings later?
+
+    /* major, minor, revision */
+    int parts[3] = {0, 0, 0};
+    int current = 0, started_at = 0;
+    int len = strlen(version_str);
+    for (int i = 0; i < len + 1; i++)
+    {
+        /* read until . or EOF, then extract that section */
+        if (version_str[i] == '.' || version_str[i] == '\0')
+        {
+            int sect_len = i - started_at;
+            if (sect_len == 0)
+            {
+                /* ??? */
+                return rrc_result_create_error_corrupted_versionfile("Invalid format");
+            }
+
+            /* read this section */
+            char section[sect_len + 1];
+            int idx = 0;
+            for (int j = started_at; j < started_at + sect_len; j++)
+            {
+                section[idx] = version_str[j];
+                idx++;
+            }
+            section[sect_len] = '\0';
+
+            int section_l = strtol(section, NULL, 10);
+            parts[current] = section_l;
+            current++;
+            if (current > 2)
+            {
+                /* we read the rev now */
+                break;
+            }
+
+            started_at = i + 1;
+        }
+    }
+
+    out_version->major = parts[0];
+    out_version->minor = parts[1];
+    out_version->patch = parts[2];
+
+    return rrc_result_success;
+}
+
+bool rrc_version_equals(const struct rrc_version *a, const struct rrc_version *b)
+{
+    return (a->major == b->major) && (a->minor == b->minor) && (a->patch == b->patch);
+}

--- a/source/version.h
+++ b/source/version.h
@@ -1,0 +1,41 @@
+/*
+    version.h - version structure and related functions
+
+    Copyright (C) 2025  Retro Rewind Team
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef RRC_VERSION_H
+#define RRC_VERSION_H
+
+#include <gctypes.h>
+#include "result.h"
+
+struct rrc_version
+{
+    int major;
+    int minor;
+    int patch;
+};
+
+/// Returns true if version a is older than version b, false otherwise
+bool rrc_version_is_older(const struct rrc_version *a, const struct rrc_version *b);
+
+/// Parses a version string of the format "major.minor.patch" into a rrc_version struct. Returns an error if the format is invalid.
+struct rrc_result rrc_version_from_string(const char *version_str, struct rrc_version *out_version);
+
+bool rrc_version_equals(const struct rrc_version *a, const struct rrc_version *b);
+
+#endif /* RRC_VERSION_H */


### PR DESCRIPTION
Still only 3 digit, but should work with a.b.c where a>9, b>9, c>9