### PR TITLE
Free settingsfile result after showing prompt

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -207,9 +207,8 @@ int main(int argc, char **argv)
             "It may be possible to fix this by recreating the file.",
             "Recreate now?",
         };
-        rrc_result_free(settingsfile_res);
-
         enum rrc_prompt_result prompt_res = rrc_prompt_yes_no(xfb, lines, 4);
+        rrc_result_free(settingsfile_res);
 
         if (prompt_res == RRC_PROMPT_RESULT_YES)
         {


### PR DESCRIPTION
Use-after-free bug I found while reviewing #86 (not introduced there, but the piece of code was moved around):

I haven't found this causing an actual visible issue in practice, but always good to remove use-after-free bugs.

On L206 we took the context string pointer and put it in the `lines` array. Then on L210 we (used to) *free* the result (along with the context string). Then on L212, *after* freeing the result and its context, we try to print the lines containing the context string.
Easy to fix by just swapping the two lines.