### PR TITLE
Misc improvements

### DIFF
--- a/runtime-ext/source/dvd.c
+++ b/runtime-ext/source/dvd.c
@@ -185,7 +185,7 @@ static bool rte_dvd_resolve_my_stuff_path_to_entry_num(const char *path, s32 *en
     // Work backwards since it's likely it's near the end of the list.
     struct rrc_riivo_disc_replacement *my_stuff_replacement = NULL;
 
-    if(my_stuff_replacement_idx >= 0)
+    if (my_stuff_replacement_idx >= 0)
     {
         my_stuff_replacement = &riivo_disc->replacements[my_stuff_replacement_idx];
         if (my_stuff_replacement->type != RRC_RIIVO_MY_STUFF_REPLACEMENT)
@@ -240,7 +240,7 @@ static bool rte_dvd_resolve_my_stuff_path_to_entry_num(const char *path, s32 *en
     }
 
     bool cached_file_exists = false;
-    for(int i = 0; i < my_stuff_replacement->folder_contents_count; i++)
+    for (int i = 0; i < my_stuff_replacement->folder_contents_count; i++)
     {
         if (strcmp(my_stuff_replacement->folder_contents[i], filename) == 0)
         {
@@ -264,9 +264,9 @@ static bool rte_dvd_resolve_my_stuff_path_to_entry_num(const char *path, s32 *en
 char *strstr1(const char *s1, const char *s2)
 {
     size_t n = strlen(s2);
-    while(*s1)
-        if(!memcmp(s1++,s2,n))
-            return (char *) (s1-1);
+    while (*s1)
+        if (!memcmp(s1++, s2, n))
+            return (char *)(s1 - 1);
     return 0;
 }
 
@@ -293,7 +293,7 @@ static bool rte_dvd_resolve_path_to_entry_num(const char *filename, s32 *entry_n
         case RRC_RIIVO_FILE_REPLACEMENT:
         {
             RTE_DBG("Checking file replacement: '%s' == '%s'\n", replacement->disc, "strm");
-            
+
             // Trim leading slashes from either path.
             const char *disc_path = replacement->disc;
             if (*disc_path == '/')
@@ -326,6 +326,18 @@ static bool rte_dvd_resolve_path_to_entry_num(const char *filename, s32 *entry_n
             if (disc_len > filename_len)
             {
                 break;
+            }
+
+            bool looking_for_patches = strstr1(filename, "patches") != NULL;
+
+            if (looking_for_patches)
+            {
+                OS_Report("\n\n\n\nFolder contents count: %d (external path: %s, disc path: %s, filename: %s)\n", replacement->folder_contents_count, replacement->external, disc_path, filename);
+                for (int i = 0; i < replacement->folder_contents_count; i++)
+                {
+                    OS_Report(" - %s\n", replacement->folder_contents[i]);
+                }
+                OS_Report("\n\n\n\n");
             }
 
             // Check if this folder path is a prefix of the given filename (`matches`),
@@ -391,10 +403,10 @@ static bool rte_dvd_resolve_path_to_entry_num(const char *filename, s32 *entry_n
                 bool cached_file_exists = false;
                 for (int i = 0; i < replacement->folder_contents_count; i++)
                 {
-                    // We need to enforce case insensitivity here because FAT is case-insensitive, 
+                    // We need to enforce case insensitivity here because FAT is case-insensitive,
                     // and the folder_contents are populated based on FAT reads.
 
-                    to_lowercase((char*) replacement->folder_contents[i]);
+                    to_lowercase((char *)replacement->folder_contents[i]);
                     to_lowercase(new_path_filename);
 
                     if (strcmp(replacement->folder_contents[i], new_path_filename) == 0)
@@ -413,7 +425,7 @@ static bool rte_dvd_resolve_path_to_entry_num(const char *filename, s32 *entry_n
                 }
                 else
                 {
-                    RTE_DBG("NOTE: %s not applied because it doesn't exist.\n", disc_path);
+                    OS_Report("NOTE: %s/%s not applied because it doesn't exist.\n", external_path, new_path_filename);
                 }
             }
 
@@ -451,7 +463,7 @@ static void rte_dvd_open_entry_num(s32 entry_num, FileInfo *file_info)
 
         if (fd == -1)
         {
-            RTE_FATAL("FastOpen: SD error (%d)!\n", errno);
+            RTE_FATAL("FastOpen: SD error!\n\nOpen path '%s'\nfailed with error %d\n", etp->path, errno);
         }
 
         if (fd != (u32)file)

--- a/runtime-ext/source/dvd.c
+++ b/runtime-ext/source/dvd.c
@@ -328,18 +328,6 @@ static bool rte_dvd_resolve_path_to_entry_num(const char *filename, s32 *entry_n
                 break;
             }
 
-            bool looking_for_patches = strstr1(filename, "patches") != NULL;
-
-            if (looking_for_patches)
-            {
-                OS_Report("\n\n\n\nFolder contents count: %d (external path: %s, disc path: %s, filename: %s)\n", replacement->folder_contents_count, replacement->external, disc_path, filename);
-                for (int i = 0; i < replacement->folder_contents_count; i++)
-                {
-                    OS_Report(" - %s\n", replacement->folder_contents[i]);
-                }
-                OS_Report("\n\n\n\n");
-            }
-
             // Check if this folder path is a prefix of the given filename (`matches`),
             // and if it is, find the "split" point at which they differ (`differ_index`). Example:
             // Game requests "Assets/RaceAssets.szs", folder replacement is "/Assets" -> "/CustomAssets".

--- a/runtime-ext/source/dvd.c
+++ b/runtime-ext/source/dvd.c
@@ -413,7 +413,7 @@ static bool rte_dvd_resolve_path_to_entry_num(const char *filename, s32 *entry_n
                 }
                 else
                 {
-                    OS_Report("NOTE: %s/%s not applied because it doesn't exist.\n", external_path, new_path_filename);
+                    RTE_DBG("NOTE: %s/%s not applied because it doesn't exist.\n", external_path, new_path_filename);
                 }
             }
 

--- a/source/main.c
+++ b/source/main.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
     // There are bugs in pulsar with USB/HIDv5 if the IOS version is 59, which HBC commonly boots programs with.
     // Use a version used by the game that is known to work with pulsar.
     // FIXME: try to use the disk's IOS version?
-    RRC_ASSERTEQ(IOS_ReloadIOS(37), 0, "Failed to reload IOS");
+    //RRC_ASSERTEQ(IOS_ReloadIOS(37), 0, "Failed to reload IOS");
 
     rrc_shutdown_register_callbacks();
 

--- a/source/main.c
+++ b/source/main.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
     // There are bugs in pulsar with USB/HIDv5 if the IOS version is 59, which HBC commonly boots programs with.
     // Use a version used by the game that is known to work with pulsar.
     // FIXME: try to use the disk's IOS version?
-    //RRC_ASSERTEQ(IOS_ReloadIOS(37), 0, "Failed to reload IOS");
+    RRC_ASSERTEQ(IOS_ReloadIOS(37), 0, "Failed to reload IOS");
 
     rrc_shutdown_register_callbacks();
 

--- a/source/result.c
+++ b/source/result.c
@@ -154,14 +154,20 @@ void rrc_result_error_check_error_normal(struct rrc_result result, void *xfb)
     char line1[cols];
     snprintf(line1, cols, "Error: %s", rrc_result_strerror(result));
 
+    char *newline_ptr = strchr((char *)result.err->context, '\n');
+    if(newline_ptr) {
+        *newline_ptr = '\0';
+    }
+
     char *lines[] = {
         line1,
         "",
         "Additional info:",
         (char *)result.err->context,
+        newline_ptr ? newline_ptr + 1 : ""
     };
 
-    rrc_prompt_1_option(xfb, lines, 4, "OK");
+    rrc_prompt_1_option(xfb, lines, 5, "OK");
     rrc_result_free(result);
 }
 

--- a/source/sd.c
+++ b/source/sd.c
@@ -65,7 +65,7 @@ struct rrc_result rrc_sd_init()
     rewind(file);
     
     // Read the file and parse the version to check the write worked
-    char buf[5] = {0};
+    char buf[6] = {0};
     if (fread(buf, 1, 5, file) <= 0)
     {   
         fclose(file);

--- a/source/sd.c
+++ b/source/sd.c
@@ -32,6 +32,10 @@ struct rrc_result rrc_sd_init()
         return rrc_result_create_error_sdcard(EIO, "Couldn't start SD card interface - is it inserted?");
     }
 
+    if(!__io_wiisd.isInserted()) {
+        return rrc_result_create_error_sdcard(EIO, "No SD card is inserted.");
+    }
+
     /* __io_wiisd caches state so the fat driver won't reinit */
     if (!fatInitDefault())
     {

--- a/source/sd.c
+++ b/source/sd.c
@@ -23,39 +23,57 @@
 #include "sd.h"
 #include <sys/dirent.h>
 #include "update/update.h"
+#include <sdcard/wiisd_io.h>
 
 struct rrc_result rrc_sd_init()
 {
+    /* Manually check if the SD card interface is available */
+    if(!__io_wiisd.startup()) {
+        return rrc_result_create_error_sdcard(EIO, "Couldn't start SD card interface - is it inserted?");
+    }
+
+    /* __io_wiisd caches state so the fat driver won't reinit */
     if (!fatInitDefault())
     {
-        return rrc_result_create_error_sdcard(EIO, "Couldn't mount the SD card - is it inserted?");
+        return rrc_result_create_error_sdcard(EIO, "Couldn't mount the SD card. Is it inserted and properly formatted?");
     }
 
     if (chdir("sd:/") == -1)
     {
-        return rrc_result_create_error_errno(errno, "Failed to set SD card root");
+        return rrc_result_create_error_sdcard(EIO, "Failed to set SD card root");
     }
 
     FILE *file = fopen(RRC_SD_TEST_FILE, "w+");
     if (!file)
     {
-        return rrc_result_create_error_errno(errno, "The SD card is locked.");
+        return rrc_result_create_error_sdcard(EIO, "The SD card is write locked.");
     }
 
     // Test writing to the SD card, then clean up the test file.
-    int res = fprintf(file, "Test");
-    fflush(file);
+    int res = fwrite("1.2.3", 1, 5, file);
 
     if (res <= 0) {
         fclose(file);
-        return rrc_result_create_error_errno(errno, "The SD card is locked.");
+        return rrc_result_create_error_sdcard(EIO, "The SD card is write locked.");
     }
-    fclose(file);
 
-    file = fopen(RRC_VERSIONFILE, "r");
-    if (file == NULL)
+    fflush(file);
+    rewind(file);
+    
+    // Read the file and parse the version to check the write worked
+    char buf[5] = {0};
+    if (fread(buf, 1, 5, file) <= 0)
+    {   
+        fclose(file);
+        return rrc_result_create_error_sdcard(EIO, "The SD card is write locked.");
+    }
+
+    struct rrc_version ver;
+    struct rrc_result verres = rrc_version_from_string(buf, &ver);
+    if (rrc_result_is_error(verres))
     {
-        return rrc_result_create_error_errno(errno, "Failed to open version file.\nThis can happen if the SD card is locked,\nor your Retro Rewind installation is corrupted.");
+        fclose(file);
+        return rrc_result_create_error_sdcard(EIO, "The SD card is write locked.");
     }
 
     fclose(file);
@@ -116,15 +134,15 @@ int rrc_sd_get_folder_file_count(const char *path, struct rrc_result *out_err)
     return count;
 }
 
-struct rrc_result rrc_sd_get_free_space(unsigned long *res)
+struct rrc_result rrc_sd_get_free_space(unsigned long long *res)
 {
     struct statvfs sbx;
-    int rr = statvfs("/dev/sd", &sbx);
+    int rr = statvfs("sd:", &sbx);
     if (rr != 0)
     {
         return rrc_result_create_error_errno(errno, "Failed to get free space on SD card");
     }
 
-    *res = sbx.f_bavail * sbx.f_frsize;
+    *res = sbx.f_bfree * sbx.f_frsize;
     return rrc_result_success;
 }

--- a/source/sd.h
+++ b/source/sd.h
@@ -22,7 +22,7 @@
 
 #include "result.h"
 
-#define RRC_SD_TEST_FILE ".sdtest"
+#define RRC_SD_TEST_FILE "/RetroRewindChannel/.sdtest"
 
 /*
     Initialises and tests the SD card slot.
@@ -48,9 +48,8 @@ bool rrc_sd_folder_exists(const char *path);
  */
 int rrc_sd_get_folder_file_count(const char *path, struct rrc_result *out_err);
 
-/**
-    Returns the amount of free space on the sd card in bytes.
+/*
+    Returns amount of free space on sd card as bytes.
 */
-struct rrc_result rrc_sd_get_free_space(unsigned long *res);
-
+struct rrc_result rrc_sd_get_free_space(unsigned long long *res);
 #endif

--- a/source/update/update.c
+++ b/source/update/update.c
@@ -36,8 +36,9 @@
 #include "../prompt.h"
 #include "../shutdown.h"
 #include "../version.h"
+#include "../sd.h"
 
-#define _RRC_UPDATE_ZIP_NAME "update.zip"
+#define _RRC_UPDATE_ZIP_NAME "rr.update.zip"
 
 struct rrc_result rrc_update_get_current_version(struct rrc_version *version)
 {
@@ -277,6 +278,35 @@ struct rrc_result rrc_update_extract_zip_archive()
     }
 
     u32 zip_entries = zip_get_num_entries(archive, 0);
+    // Find the total uncompressed size of the archive
+    u64 uncompressed_zipsz = 0;
+    for (int i = 0; i < zip_entries; i++)
+    {
+        zip_stat_t stat;
+        zip_stat_init(&stat);
+
+        int err = zip_stat_index(archive, i, 0, &stat);
+        if (err != 0)
+        {
+            return rrc_result_create_error_zip(err, "Failed to stat file in archive");
+        }
+
+        if (stat.valid & ZIP_STAT_SIZE)
+        {
+            uncompressed_zipsz += stat.size;
+        }
+    }
+
+    unsigned long long sd_free;
+    TRY(rrc_sd_get_free_space(&sd_free));
+
+    if (uncompressed_zipsz > sd_free)
+    {
+        // Report sizes
+        char msg[200];
+        snprintf(msg, 200, "Not enough free space on SD card to extract update.\n(Need %llu bytes, have %llu bytes)", (u64)uncompressed_zipsz, (u64)sd_free);
+        return rrc_result_create_error_misc_update(msg);
+    }
 
     char buf[4096];
 
@@ -299,12 +329,14 @@ struct rrc_result rrc_update_extract_zip_archive()
             return rrc_result_create_error_misc_update("Empty file name in ZIP archive");
         }
 
-        unsigned long sd_free;
+        unsigned long long sd_free;
         TRY(rrc_sd_get_free_space(&sd_free));
 
         if (stat.size > sd_free)
         {
-            return rrc_result_create_error_misc_update("Not enough free space on SD card for update");
+            char msg[200];
+            snprintf(msg, 200, "Not enough free space on SD card to extract file.\nNeeded: %llu bytes, available: %llu bytes", stat.size, sd_free);
+            return rrc_result_create_error_misc_update(msg);
         }
 
         if (stat.name[strlen(stat.name) - 1] == '/')
@@ -418,12 +450,14 @@ struct rrc_result rrc_update_do_updates_with_state(struct rrc_update_state *stat
             return rrc_result_create_error_curl(szres, "Failed to get update ZIP size");
         }
 
-        unsigned long sd_free;
+        unsigned long long sd_free;
         TRY(rrc_sd_get_free_space(&sd_free));
 
-        if (zipsz > sd_free)
+        if (zipsz > sd_free || true) 
         {
-            return rrc_result_create_error_misc_update("Not enough free space on SD card for update");
+            char msg[200];
+            snprintf(msg, 200, "Not enough free space on SD card for update ZIP.\nNeeded: %llu bytes, available: %llu bytes", zipsz, sd_free);
+            return rrc_result_create_error_misc_update(msg);
         }
 
         TRY(rrc_update_download_zip(url, _RRC_UPDATE_ZIP_NAME, state->current_update_num, state->num_updates));

--- a/source/update/update.c
+++ b/source/update/update.c
@@ -112,6 +112,18 @@ int est_sec_remaining = 0;
 int last_10_sec_dl_amount[10] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
 int next_second_write_index = 0;
 
+void _rrc_cleanup_measurement_state()
+{
+    lp = -1;
+    last_measurement_from = -1;
+    last_dlnow = 0;
+    dl_speed_avg = 0;
+    est_sec_remaining = 0;
+    for(int i = 0; i < 10; i++)
+        last_10_sec_dl_amount[i] = -1;
+    next_second_write_index = 0;
+}
+
 void _rrc_zipdl_est_time_remaining_fmt(int est_sec_remaining, char* out, int out_sz)
 {
     if (est_sec_remaining < 60)
@@ -171,6 +183,8 @@ int _rrc_zipdl_progress_callback(int *numinfo,
             next_second_write_index = 0;
 
         dl_speed_avg = dl_speed_sum / 10;
+        if(dl_speed_avg == 0)
+            dl_speed_avg = 1; // Avoid division by zero
         est_sec_remaining = remaining_dl / dl_speed_avg;
     }
 
@@ -271,14 +285,18 @@ struct rrc_result rrc_update_download_zip(char *url, char *filename, int current
 
             fclose(fp);
             curl_easy_cleanup(curl);
+            _rrc_cleanup_measurement_state();
             return rrc_result_create_error_curl(cres, "Failed to download update ZIP");
         }
 
         fclose(fp);
         curl_easy_cleanup(curl);
+        _rrc_cleanup_measurement_state();
+
         return rrc_result_success;
     }
 
+    _rrc_cleanup_measurement_state();
     return rrc_result_create_error_curl(CURLE_FAILED_INIT, "Failed to init curl");
 }
 

--- a/source/update/update.c
+++ b/source/update/update.c
@@ -107,7 +107,31 @@ struct rrc_result rrc_update_set_current_version(struct rrc_version *version)
 int lp = -1;
 rrc_time_tick last_measurement_from = -1;
 curl_off_t last_dlnow = 0;
-int last_second_dl_amount = 0;
+int dl_speed_avg = 0;
+int est_sec_remaining = 0;
+int last_10_sec_dl_amount[10] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+int next_second_write_index = 0;
+
+void _rrc_zipdl_est_time_remaining_fmt(int est_sec_remaining, char* out, int out_sz)
+{
+    if (est_sec_remaining < 60)
+    {
+        snprintf(out, out_sz, "%i seconds", est_sec_remaining);
+    }
+    else if (est_sec_remaining < 3600)
+    {
+        int min_remaining = est_sec_remaining / 60;
+        int sec_remaining = est_sec_remaining % 60;
+        snprintf(out, out_sz, "%im %is", min_remaining, sec_remaining);
+    }
+    else
+    {
+        int hr_remaining = est_sec_remaining / 3600;
+        int min_remaining = (est_sec_remaining % 3600) / 60;
+        int sec_remaining = est_sec_remaining % 60;
+        snprintf(out, out_sz, "%ih %im %is", hr_remaining, min_remaining, sec_remaining);
+    }
+}
 
 int _rrc_zipdl_progress_callback(int *numinfo,
                                  curl_off_t dltotal,
@@ -117,7 +141,6 @@ int _rrc_zipdl_progress_callback(int *numinfo,
 {
     /* 100kB chunks */
 #define _RRC_PROGRESS_UPD_CHUNKSIZE 100000
-
     /* update download speed every second */
 #define _RRC_PROGRESS_UPD_SPEED_INC 1000
     int progress = (dlnow * 100) / dltotal;
@@ -126,24 +149,49 @@ int _rrc_zipdl_progress_callback(int *numinfo,
     {
         last_measurement_from = gettime();
 
-        last_second_dl_amount = dlnow - last_dlnow;
+        int last_second_dl_amount = dlnow - last_dlnow;
         last_dlnow = dlnow;
+        int remaining_dl = dltotal - dlnow;
+
+        // We take an average of the last 10 seconds of downloading to produce the estimate
+        // On the first pass we flood all 10 seconds with the first reading then move
+        // through the list as a ringbuffer.
+        int dl_speed_sum = 0;
+
+        for(int i = 0; i < 10; i++)
+        {
+            if(last_10_sec_dl_amount[i] == -1)
+                last_10_sec_dl_amount[i] = last_second_dl_amount;
+            dl_speed_sum += last_10_sec_dl_amount[i];
+        }
+
+        last_10_sec_dl_amount[next_second_write_index] = last_second_dl_amount;
+        next_second_write_index++;
+        if(next_second_write_index >= 10) 
+            next_second_write_index = 0;
+
+        dl_speed_avg = dl_speed_sum / 10;
+        est_sec_remaining = remaining_dl / dl_speed_avg;
     }
 
     int chunk = dlnow / _RRC_PROGRESS_UPD_CHUNKSIZE;
     if (chunk != lp)
     {
+        char est_time_remaining_fmt[100];
+        _rrc_zipdl_est_time_remaining_fmt(est_sec_remaining, est_time_remaining_fmt, sizeof(est_time_remaining_fmt));
+
         lp = chunk;
         char msg[100];
         snprintf(
             msg,
             100,
-            "Downloading update %i of %i - %i kB/s (%i/%i kB)",
+            "Downloading update %i of %i - %i kB/s (%i/%i kB)\n Est time remaining: %s",
             ((*numinfo) / 100) + 1,
             (*numinfo) % 100,
-            (int)(last_second_dl_amount / 1000),
+            (int)(dl_speed_avg / 1000),
             (int)(dlnow / (curl_off_t)1000),
-            (int)(dltotal / (curl_off_t)1000));
+            (int)(dltotal / (curl_off_t)1000),
+            est_time_remaining_fmt);
 
         rrc_con_update(msg, progress);
     }
@@ -354,7 +402,7 @@ struct rrc_result rrc_update_extract_zip_archive()
         const char *filepath = stat.name;
 
         char message[128];
-        snprintf(message, sizeof(message), "Extracting %s (%d/%d)", filepath, i + 1, zip_entries);
+        snprintf(message, sizeof(message), "Extract %s (%d/%d)", filepath, i + 1, zip_entries);
         rrc_con_update(message, ((f64)(i + 1) / (f64)zip_entries) * 100);
 
         FILE *outfile = fopen(filepath, "w");
@@ -453,7 +501,7 @@ struct rrc_result rrc_update_do_updates_with_state(struct rrc_update_state *stat
         unsigned long long sd_free;
         TRY(rrc_sd_get_free_space(&sd_free));
 
-        if (zipsz > sd_free || true) 
+        if (zipsz > sd_free) 
         {
             char msg[200];
             snprintf(msg, 200, "Not enough free space on SD card for update ZIP.\nNeeded: %llu bytes, available: %llu bytes", zipsz, sd_free);


### PR DESCRIPTION
- Checks if the SD card is inserted, as well as attempting to start it up separately to the filesystem. This helps separate SD card hardware issues from filesystem issues.
- Add an estimated time remaining to update downloads.
- Support newline in error output.
- Check extracted ZIP size before extracting any files, to make sure we don't run out of space halfway through extracting an update.