### PR TITLE
Fix ConvertPathToEntrynum falsely matching subpath that doesn't exist

### DIFF
--- a/runtime-ext/source/dvd.c
+++ b/runtime-ext/source/dvd.c
@@ -377,15 +377,15 @@ static bool rte_dvd_resolve_path_to_entry_num(const char *filename, s32 *entry_n
                 strncpy(path_ptr, filename + differ_index, 64 - ((u32)path_ptr - (u32)new_path));
 
                 RTE_DBG("Checking for folder replacement path '%s' (external_path='%s', filename='%s', disc_path='%s')\n", new_path, external_path, filename, disc_path);
-                // Let's extract the filename from the path and see if exists in replacement->folder_contents.
-                char *new_path_filename = strrchr(new_path, '/');
-                if (new_path_filename)
+
+                // `path_ptr` (and `new_path_filename`) now points right after the common prefix (so usually the filename),
+                // which we will use to check against the folder contents.
+                // But first, there might be a `/` here still for e.g. `disc=/b requested=/b/c`:
+                // new_path_filename` will point at `/c` (differ_index=2), but we only want `c`, so skip it.
+                char *new_path_filename = path_ptr;
+                if (*new_path_filename == '/')
                 {
                     new_path_filename++;
-                }
-                else
-                {
-                    new_path_filename = new_path;
                 }
 
                 bool cached_file_exists = false;
@@ -451,7 +451,7 @@ static void rte_dvd_open_entry_num(s32 entry_num, FileInfo *file_info)
 
         if (fd == -1)
         {
-            RTE_FATAL("FastOpen: SD error!");
+            RTE_FATAL("FastOpen: SD error (%d)!\n", errno);
         }
 
         if (fd != (u32)file)


### PR DESCRIPTION
Fixes a crash in FastOpen() where ConvertPathToEntrynum() would falsely allocate an entrynum for a file that doesn't actually exist. Tested on dolphin, error is gone and patches seem to work (tested with a simple la_bike-fk.szs replacement)

TL;DR: change the cached folder check from extracting just the filename (which may drop other segments that need to be compared) to comparing the full remaining path after the common prefix.

<details>
<summary>Longer explanation</summary>

Normally, when we're considering the node `<folder external="/RetroRewind6/Assets" disc="/">` and we have a file in `/RetroRewind6/Assets/ReplacedAssets.szs`, and the game requests `/patches/ReplacedAssets.szs`, this should *not* match, because what's supposed to happen is it finds the common prefix of the disc path and requested path (just "/" here) and then append the rest onto the external path: `/RetroRewind6/Assets/patches/ReplacedAssets.szs`; this file doesn't exist and thus should be ignored. 

The problem with the cached implementation is that it only took the filename segment (ReplacedAssets.szs) and checked if it's in the folder contents of `/RetroRewind6/Assets`: it is, but that ignores that the requested file was supposed to be in a `patches/` subfolder.
So this changes it such that it compares the full remaining portion after the common prefix (`differ_index`) (usually this will just be a filename and the change won't make a difference, but in this example it would end up comparing "patches/ReplacedAssets.szs" == "ReplacedAssets.szs", which as expected no longer falsely matches)
</details>
