### PR TITLE
Implement main.dol replacements

### DIFF
--- a/source/loader/loader.c
+++ b/source/loader/loader.c
@@ -158,7 +158,7 @@ void rrc_loader_load(struct rrc_dol *dol, struct rrc_settingsfile *settings, voi
 
     rrc_con_update("Load Patch Information", 80);
     struct parse_riivo_output riivo_out;
-    res = rrc_riivo_patch_loader_parse(settings, &mem1_hi, &mem2_hi, &riivo_out);
+    res = rrc_riivo_patch_loader_parse(settings, dol, &mem1_hi, &mem2_hi, &riivo_out);
     rrc_result_error_check_error_fatal(res);
 
     rrc_con_update("Patch DVD Functions", 85);

--- a/source/loader/riivo_patch_loader.c
+++ b/source/loader/riivo_patch_loader.c
@@ -131,7 +131,13 @@ static struct rrc_result rrc_patch_loader_append_patches_for_option(
     return rrc_result_create_error_corrupted_rr_xml("option not found in xml");
 }
 
-// Only need to track immediate files in this folder.
+/**
+ * Collects all *direct* files (does not visit subdirectories) in the given folder and returns them.
+ *
+ * `main_dol_replacement_path` may be NULL, in which case main.dol is ignored,
+ * but if it's non-null, the external SD path will be copied into it
+ * (this is a slight hack that will be cleaned up as part of the replacement rework).
+ */
 const char **rrc_riivo_patch_loader_get_entries_in_replaced_folder(u32 *arena,
                                                                    const char *folder_path,
                                                                    int *out_count,
@@ -158,8 +164,11 @@ const char **rrc_riivo_patch_loader_get_entries_in_replaced_folder(u32 *arena,
 
         if (strcmp(entry->d_name, "main.dol") == 0)
         {
-            snprintf(main_dol_replacement_path, PATH_MAX, "%s/main.dol", folder_path);
-            continue; // No need to store this entry as main.dol is never needed at runtime.
+            if (main_dol_replacement_path != NULL)
+            {
+                snprintf(main_dol_replacement_path, PATH_MAX, "%s/main.dol", folder_path);
+            }
+            continue; // No need to store this entry in any case as main.dol is never replaced at runtime.
         }
 
         if (i >= cap)
@@ -353,7 +362,7 @@ struct rrc_result rrc_riivo_patch_loader_parse(struct rrc_settingsfile *settings
                 char *external_path_m1 = bump_alloc_string(mem1, external_path_mxml);
 
                 int out_count = 0;
-                const char **folder_contents = rrc_riivo_patch_loader_get_entries_in_replaced_folder(mem1, external_path_mxml, &out_count, main_dol_replacement_path);
+                const char **folder_contents = rrc_riivo_patch_loader_get_entries_in_replaced_folder(mem1, external_path_mxml, &out_count, NULL);
 
                 total_cached_folder_files += out_count;
                 if (total_cached_folder_files >= GLOBAL_MAX_FOLDER_FILES)

--- a/source/loader/riivo_patch_loader.c
+++ b/source/loader/riivo_patch_loader.c
@@ -132,7 +132,10 @@ static struct rrc_result rrc_patch_loader_append_patches_for_option(
 }
 
 // Only need to track immediate files in this folder.
-const char **rrc_riivo_patch_loader_get_entries_in_replaced_folder(u32 *arena, const char *folder_path, int *out_count)
+const char **rrc_riivo_patch_loader_get_entries_in_replaced_folder(u32 *arena,
+                                                                   const char *folder_path,
+                                                                   int *out_count,
+                                                                   char *main_dol_replacement_path)
 {
     DIR *dir = opendir(folder_path);
     if (!dir)
@@ -142,44 +145,81 @@ const char **rrc_riivo_patch_loader_get_entries_in_replaced_folder(u32 *arena, c
         return NULL;
     }
 
-    // Count entries first, so we only allocate space for the actual entries. Inefficient, but this is why we do it here and not in-game!
-    int count = 0;
+    int cap = 4;
+    const char **entries = malloc(sizeof(char *) * cap);
+    RRC_ASSERT(entries != NULL, "OOM while allocating space for folder entries");
+
     struct dirent *entry;
-    while ((entry = readdir(dir)) != NULL)
-    {
-        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0 || entry->d_type != DT_REG)
-            continue;
-
-        count++;
-    }
-
-    if (count >= MAX_FOLDER_FILES)
-    {
-        RRC_FATAL("Too many files in folder '%s' for Riivolution patch loader! Found %d files, but max is %d", folder_path, count + 1, MAX_FOLDER_FILES);
-    }
-
-    // Reset directory stream to read entries again for storing them.
-    rewinddir(dir);
-
-    const char **entries = bump_alloc_string_array(arena, count);
     int i = 0;
     while ((entry = readdir(dir)) != NULL)
     {
         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0 || entry->d_type != DT_REG)
             continue;
 
+        if (strcmp(entry->d_name, "main.dol") == 0)
+        {
+            snprintf(main_dol_replacement_path, PATH_MAX, "%s/main.dol", folder_path);
+            continue; // No need to store this entry as main.dol is never needed at runtime.
+        }
+
+        if (i >= cap)
+        {
+            cap *= 2;
+            entries = realloc(entries, sizeof(char *) * cap);
+            RRC_ASSERT(entries != NULL, "OOM while allocating space for folder entries");
+        }
+
         char *entry_path = bump_alloc_string(arena, entry->d_name);
         entries[i] = entry_path;
         i++;
     }
 
+    if (i >= MAX_FOLDER_FILES)
+    {
+        RRC_FATAL("Too many files in folder '%s' for Riivolution patch loader! Found %d files, but max is %d", folder_path, i + 1, MAX_FOLDER_FILES);
+    }
+
+    const char **entries_m1 = bump_alloc_string_array(arena, i);
+    memcpy(entries_m1, entries, sizeof(char *) * i);
+
+    free(entries);
     closedir(dir);
 
-    *out_count = count;
-    return entries;
+    *out_count = i;
+    return entries_m1;
 }
 
-struct rrc_result rrc_riivo_patch_loader_parse(struct rrc_settingsfile *settings, u32 *mem1, u32 *mem2, struct parse_riivo_output *out)
+// Attempts to replace the previously loaded main DOL of the game with a main.dol replacement
+// from the SD card.
+static struct rrc_result rrc_replace_main_dol(struct rrc_dol *dol, const char *main_dol_replacement_path)
+{
+    FILE *main_dol = fopen(main_dol_replacement_path, "r");
+    if (!main_dol)
+    {
+        return rrc_result_create_error_errno(errno, "Failed to open main.dol replacement file");
+    }
+
+    int read;
+    char *dol_ptr = (char *)dol;
+    while ((read = fread(dol_ptr, 1, 1024, main_dol)) > 0)
+    {
+        dol_ptr += read;
+    }
+
+    if (ferror(main_dol))
+    {
+        return rrc_result_create_error_errno(errno, "Failed to read main.dol replacement");
+    }
+
+    fclose(main_dol);
+    return rrc_result_success;
+}
+
+struct rrc_result rrc_riivo_patch_loader_parse(struct rrc_settingsfile *settings,
+                                               struct rrc_dol *dol,
+                                               u32 *mem1,
+                                               u32 *mem2,
+                                               struct parse_riivo_output *out)
 {
 #define PARSE_REQUIRED_ATTR(node, var, attr)                                                                    \
     const char *var = mxmlElementGetAttr(node, attr);                                                           \
@@ -216,6 +256,9 @@ struct rrc_result rrc_riivo_patch_loader_parse(struct rrc_settingsfile *settings
 
     const char *active_patches[MAX_ENABLED_SETTINGS];
     int active_patches_count = 0;
+
+    // The SD card path to the last-encountered main.dol replacement
+    char main_dol_replacement_path[PATH_MAX] = {0};
 
     mxml_index_t *options_index = mxmlIndexNew(xml_top, "option", NULL);
 
@@ -310,7 +353,7 @@ struct rrc_result rrc_riivo_patch_loader_parse(struct rrc_settingsfile *settings
                 char *external_path_m1 = bump_alloc_string(mem1, external_path_mxml);
 
                 int out_count = 0;
-                const char **folder_contents = rrc_riivo_patch_loader_get_entries_in_replaced_folder(mem1, external_path_mxml, &out_count);
+                const char **folder_contents = rrc_riivo_patch_loader_get_entries_in_replaced_folder(mem1, external_path_mxml, &out_count, main_dol_replacement_path);
 
                 total_cached_folder_files += out_count;
                 if (total_cached_folder_files >= GLOBAL_MAX_FOLDER_FILES)
@@ -359,7 +402,7 @@ struct rrc_result rrc_riivo_patch_loader_parse(struct rrc_settingsfile *settings
             char *external_path_m1 = bump_alloc_string(mem1, external_path_mxml);
 
             int out_count = 0;
-            const char **folder_contents = rrc_riivo_patch_loader_get_entries_in_replaced_folder(mem1, external_path_mxml, &out_count);
+            const char **folder_contents = rrc_riivo_patch_loader_get_entries_in_replaced_folder(mem1, external_path_mxml, &out_count, main_dol_replacement_path);
 
             total_cached_folder_files += out_count;
             if (total_cached_folder_files >= GLOBAL_MAX_FOLDER_FILES)
@@ -424,6 +467,11 @@ struct rrc_result rrc_riivo_patch_loader_parse(struct rrc_settingsfile *settings
             }
         }
         mxmlIndexDelete(memory_index);
+    }
+
+    if (main_dol_replacement_path[0] != '\0')
+    {
+        TRY(rrc_replace_main_dol(dol, main_dol_replacement_path));
     }
 
     // This address is a `static` in the runtime-ext dol that holds a pointer to the replacements, defined in the linker script.

--- a/source/loader/riivo_patch_loader.h
+++ b/source/loader/riivo_patch_loader.h
@@ -21,6 +21,7 @@
 #define RRC_PATCH_LOADER_H
 
 #include <mxml.h>
+#include <dol.h>
 
 #include "../settingsfile.h"
 #include "../result.h"
@@ -42,8 +43,13 @@ struct parse_riivo_output
 
 /**
  * Parses <file> and <folder> patches in the XML file and gives runtime-ext a pointer to it.
- * <memory> patches are also parsed
+ * <memory> patches are also parsed.
+ * The passed `dol` is overwritten if a main.dol replacement is encountered.
  */
-struct rrc_result rrc_riivo_patch_loader_parse(struct rrc_settingsfile *settings, u32 *mem1, u32 *mem2, struct parse_riivo_output *out);
+struct rrc_result rrc_riivo_patch_loader_parse(struct rrc_settingsfile *settings,
+                                               struct rrc_dol *dol,
+                                               u32 *mem1,
+                                               u32 *mem2,
+                                               struct parse_riivo_output *out);
 
 #endif


### PR DESCRIPTION
Closes #81. Tested on Dolphin. This works by essentially overwriting the previously loaded main game DOL at 0x8090000 with the main.dol on the SD card.

This also changes the folder contents collection code to allocate the entries in a dynamic array first and then copy them into MEM1 (this will still not over-allocate MEM1 space as the previous version intended).
My reasoning for this is that while implementing main.dol replacements I initially only added the `strcmp("main.dol")` check in the second loop and not in the first one, and that resulted in a wrong count/corruption later on which was hard to debug, so IMO this is kinda error prone having to duplicate the checks in two places.

Although if thats controversial I can revert this and just have the strcmp() in both loops, it's not required for the main purpose of this PR